### PR TITLE
Update Contact-Atlas Contact Layout.layout-meta.xml

### DIFF
--- a/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
-    <excludeButtons>RequestUseSfdc</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
@@ -35,15 +34,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>npe01__PreferredPhone__c</field>
+                <field>Email</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>npe01__HomeEmail__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Phone</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>OtherPhone</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>npe01__Preferred_Email__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>


### PR DESCRIPTION
very minor contact layout change to show Email and HomeEmail and remove PreferredPhone and PreferredEmail lists from display

I was going to do 222, but then realized since the default relationships are not showing, i thought i would leave it to Debbie.
Note, the HomeEmail is set as noneditable inthe UI. We will need a trigger to populate it from whatever is in email.

