### PR TITLE
Set up triggers and add tests

### DIFF
--- a/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger
+++ b/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger
@@ -1,0 +1,12 @@
+trigger ContentDocumentLinkTrigger on ContentDocumentLink (after insert) {
+   for (ContentDocumentLink cdl : Trigger.new) {
+        //Get Related document
+        ContentVersion cv = [
+            SELECT Id, Category__c, Type__c, Date__c, ContentDocumentId
+            FROM ContentVersion
+            WHERE ContentDocumentId = :cdl.ContentDocumentId
+            LIMIT 1
+        ];
+        FileService.updateDate(cv, cv.Date__c);
+    }
+}

--- a/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>55.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/force-app/main/default/triggers/ContentVersionTrigger.trigger
+++ b/force-app/main/default/triggers/ContentVersionTrigger.trigger
@@ -1,0 +1,12 @@
+trigger ContentVersionTrigger on ContentVersion (after update) {
+   for (ContentVersion newCv : Trigger.new) {
+        //Get Old Value
+        ContentVersion oldCv = trigger.oldMap.get(newCv.Id);
+        Date oldDate = oldCv.Date__c;
+        
+        // Check if value is updated
+        if (oldDate != newCv.Date__c) {
+            FileService.updateDate(newCv, newCv.Date__c);
+        }
+    }
+}

--- a/force-app/main/default/triggers/ContentVersionTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/ContentVersionTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>55.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/force-app/main/test/TestContentDocumentLinkTrigger.cls
+++ b/force-app/main/test/TestContentDocumentLinkTrigger.cls
@@ -1,0 +1,41 @@
+@isTest
+public with sharing class TestContentDocumentLinkTrigger {
+    @isTest
+    static void insert_setsLastDate() {
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow'
+        );
+        insert joe;
+        Id joeId = joe.Id;
+
+        ContentVersion cv = new ContentVersion(
+            Title = 'Test Category Type',
+            PathOnClient = 'TestDocument3.jpg',
+            Origin = 'H',
+            VersionData = Blob.valueOf('Document Body 3'),
+            Category__c = 'Client',
+            Type__c = 'Application',
+            Date__c = Date.today()
+        );
+        insert cv;
+		cv = [SELECT Id, ContentDocumentId, Date__c FROM ContentVersion WHERE id = :cv.Id LIMIT 1];
+
+        ContentDocumentLink link = new ContentDocumentLink(
+            ContentDocumentId = cv.ContentDocumentId,
+            LinkedEntityId = joeId
+        );
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.insert(link, false);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT ClientApplicationReceived__c FROM Contact WHERE id=:joe.Id LIMIT 1];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(cv.Date__c, saved.ClientApplicationReceived__c);
+    }
+}

--- a/force-app/main/test/TestContentDocumentLinkTrigger.cls-meta.xml
+++ b/force-app/main/test/TestContentDocumentLinkTrigger.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/TestContentVersionTrigger.cls
+++ b/force-app/main/test/TestContentVersionTrigger.cls
@@ -1,0 +1,29 @@
+@isTest
+public with sharing class TestContentVersionTrigger {
+    @isTest
+    static void insert_setsLastDate() {
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow'
+        );
+        insert joe;
+        System.debug(joe.Id);
+
+        ContentVersion cv = TestFileService.createLink('Client', 'Application', Date.today(), joe.Id);
+        // change the date
+        cv.Date__c = Date.today().addDays(1);
+        System.debug(cv);
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(cv, false);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT ClientApplicationReceived__c FROM Contact WHERE id=:joe.Id LIMIT 1];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(cv.Date__c, saved.ClientApplicationReceived__c);
+    }
+}

--- a/force-app/main/test/TestContentVersionTrigger.cls-meta.xml
+++ b/force-app/main/test/TestContentVersionTrigger.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/TestFileService.cls
+++ b/force-app/main/test/TestFileService.cls
@@ -1,6 +1,6 @@
 @isTest
 public with sharing class TestFileService {
-    private static ContentVersion createLink(
+    public static ContentVersion createLink(
         string category,
         string type,
         Date docDate,


### PR DESCRIPTION
For update to ContentDocumentLink and ContentVersion.
The date is only updated when it is newer.  Not 100% sure this is the behavior we want.



# Critical Changes

# Changes

# Issues Closed
