### PR TITLE
Add PreferredName to Contact

### DIFF
--- a/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
+    <excludeButtons>RequestUseSfdc</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
@@ -13,6 +14,10 @@
             <layoutItems>
                 <behavior>Required</behavior>
                 <field>Name</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>PreferredName__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -668,7 +673,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1g000004XJdA</masterLabel>
+        <masterLabel>00h7e000001ih8f</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/lwc/newContactCmp/newContactCmp.html
+++ b/force-app/main/default/lwc/newContactCmp/newContactCmp.html
@@ -10,6 +10,7 @@
                     <lightning-input-field field-name={field.name} required></lightning-input-field>
                 </div>
                 <div class="slds-col slds-small-size_1-of-1 slds-medium-size_1-of-2 slds-large-size_1-of-2 slds-p-horizontal_small">
+                    <lightning-input-field field-name={field.preferredName} value={preferredName}></lightning-input-field>
                     <lightning-input-field field-name={field.email} required></lightning-input-field>
                     <lightning-input-field field-name={field.phone}></lightning-input-field>
                 </div>

--- a/force-app/main/default/lwc/newContactCmp/newContactCmp.js
+++ b/force-app/main/default/lwc/newContactCmp/newContactCmp.js
@@ -5,6 +5,7 @@ import { NavigationMixin } from "lightning/navigation";
 import NAME_FIELD from "@salesforce/schema/Contact.Name";
 import EMAIL_FIELD from "@salesforce/schema/Contact.Email";
 import PHONE_FIELD from "@salesforce/schema/Contact.Phone";
+import PREFERRED_NAME_FIELD from "@salesforce/schema/Contact.PreferredName__c";
 import PRONOUN_FIELD from "@salesforce/schema/Contact.Pronoun__c";
 import PRONOUN_OTHER_FIELD from "@salesforce/schema/Contact.PronounOther__c";
 import STREET_FIELD from "@salesforce/schema/Contact.MailingStreet";
@@ -28,6 +29,7 @@ export default class NewContact extends NavigationMixin(LightningElement) {
         name: NAME_FIELD,
         email: EMAIL_FIELD,
         phone: PHONE_FIELD,
+        preferredName: PREFERRED_NAME_FIELD,
         pronoun: PRONOUN_FIELD,
         pronounOther: PRONOUN_OTHER_FIELD,
         street: STREET_FIELD,
@@ -72,6 +74,10 @@ export default class NewContact extends NavigationMixin(LightningElement) {
             this.dispatchEvent(toast);
         } else {
             this.template.querySelector("lightning-record-edit-form").submit();
+            const toast = new ShowToastEvent({
+                message: "Creating Contact."
+            });
+            this.dispatchEvent(toast);
         }
     }
 

--- a/force-app/main/default/objects/Contact/fields/PreferredName__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/PreferredName__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>PreferredName__c</fullName>
+    <description>Contact Preferred Name</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This defaults to the contact&apos;s first name, and will be filled in as such if left empty.</inlineHelpText>
+    <label>Preferred Name</label>
+    <length>128</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <applicationVisibilities>
         <application>AtlasAssistanceDogs</application>
@@ -100,6 +100,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Contact.ClientCertificationValidUntil__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Contact.ClientLOMIReceived__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -131,11 +136,6 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Contact.ClientVAPWReceived__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Contact.ClientCertificationValidUntil__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -205,8 +205,7 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field
-        >Contact.GW_Volunteers__Volunteer_Auto_Reminder_Email_Opt_Out__c</field>
+        <field>Contact.GW_Volunteers__Volunteer_Auto_Reminder_Email_Opt_Out__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -287,6 +286,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Contact.Positions__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Contact.PreferredName__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -11,5 +11,10 @@ trigger ContactTrigger on Contact (before insert, before update) {
         if (oldEmail != newContact.Email) {
             newContact.npe01__HomeEmail__c = newContact.Email;
         }
+
+        // Set PreferredName if not already set
+        if (String.isBlank(newContact.PreferredName__c)) {
+            newContact.PreferredName__c = newContact.FirstName;
+        }
     }
 }


### PR DESCRIPTION

# Critical Changes

# Changes

Added to newContact form and Atlas Contact layout
Added setting PreferredName to FirstName in Contact Trigger if blank.
Added toast when Contact form is submitted so user knows something is happening while contact is created.

# Issues Closed
#298 