### PR TITLE
The date was defaulting to today, so the date check failed.

### DIFF
--- a/force-app/main/default/triggers/ContentVersionTrigger.trigger
+++ b/force-app/main/default/triggers/ContentVersionTrigger.trigger
@@ -5,8 +5,6 @@ trigger ContentVersionTrigger on ContentVersion (after update) {
         Date oldDate = oldCv.Date__c;
         
         // Check if value is updated
-        if (oldDate != newCv.Date__c) {
-            FileService.updateDate(newCv);
-        }
+        FileService.updateDate(newCv);
     }
 }


### PR DESCRIPTION

# Critical Changes

# Changes
Removed check for date change on ContentVersion trigger so file service checks every time the record updates.
The date was defaulting to today, so wasn't showing up as a change.

# Issues Closed
#339