### PR TITLE
Propagate Team status when not active

### DIFF
--- a/force-app/main/default/classes/TeamService.cls
+++ b/force-app/main/default/classes/TeamService.cls
@@ -32,15 +32,9 @@ public with sharing class TeamService {
             update relationShip;
         }
     }
-
-    private static Set<string> inactiveStatus = new Set<string> {'Decertified', 'Discontinued'};
-    
+        
     // Update client status.  This is meant to be called from the team update trigger.
     public static void updateClientStatus(Team__c team) {
-        if (inactiveStatus.contains(team.Status__c)) {
-            return;
-        }
-
         List<Contact> clients = [SELECT ClientStatus__c, ClientCertificationValidUntil__c FROM Contact WHERE Id = :team.Client__c];
 
         if (!clients.isEmpty()) {
@@ -53,10 +47,6 @@ public with sharing class TeamService {
     
     // Update client status.  This is meant to be called from the team update trigger.
     public static void updateDogStatus(Team__c team) {
-        if (inactiveStatus.contains(team.Status__c)) {
-            return;
-        }
-
         List<Dog__c> dogs = [SELECT Status__c FROM Dog__c WHERE Id = :team.Dog__c];
 
         if (!dogs.isEmpty()) {

--- a/force-app/main/test/TestTeamTrigger.cls
+++ b/force-app/main/test/TestTeamTrigger.cls
@@ -184,15 +184,19 @@ public with sharing class TestTeamTrigger {
     }
     
     @isTest
-    public static void trigger_DoesNotUpdateClientDogStatus_WhenDecertified() {
+    public static void trigger_UpdatesClientDogStatus_WhenDecertified() {
         setup();
-        testClientDogStatus('Decertified', Date.today().addMonths(5), joe.ClientStatus__c, joe.ClientCertificationValidUntil__c);
+        string status = 'Decertified';
+        Date expected = Date.today().addMonths(5);
+        testClientDogStatus(status, expected, status, expected);
     }
     
     @isTest
-    public static void trigger_DoesNotUpdateClientDogStatus_WhenDiscontinued() {
+    public static void trigger_UpdatesClientDogStatus_WhenDiscontinued() {
         setup();
-        testClientDogStatus('Discontinued', Date.today().addMonths(5), joe.ClientStatus__c, joe.ClientCertificationValidUntil__c);
+        string status = 'Discontinued';
+        Date expected = Date.today().addMonths(5);
+        testClientDogStatus(status, expected, status, expected);
     }
     
     @isTest


### PR DESCRIPTION

# Critical Changes

# Changes
- Modified Team trigger to propagate status even when Team not active
- Updated tests

# Issues Closed
#453