### PR TITLE
Update board term valid until logic

### DIFF
--- a/force-app/main/default/classes/FileService.cls
+++ b/force-app/main/default/classes/FileService.cls
@@ -73,7 +73,8 @@ public with sharing class FileService {
             // check to see if settings are missing
             if (settings.DogExamRenewalYears__c == 0) {
                 settings = new AtlasSettings__c();
-                insert settings;
+                upsert settings;
+                settings = AtlasSettings__c.getOrgDefaults();
             }
             if (settings.LinkFilesToTeamMembers__c) {
                 linkDocumentsToTeamMember(cvs, entityId);

--- a/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BoardTermEndMonth__c</fullName>
     <defaultValue>4</defaultValue>
@@ -6,7 +6,7 @@
     <externalId>false</externalId>
     <label>Board Term End Month</label>
     <precision>2</precision>
-    <required>true</required>
+    <required>false</required>
     <scale>0</scale>
     <trackTrending>false</trackTrending>
     <type>Number</type>

--- a/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>VaccineRenewalYears__c</fullName>
-    <defaultValue>1</defaultValue>
-    <description>Years before a vaccine needs to be renewed since the last dose</description>
+    <fullName>BoardTermEndMonth__c</fullName>
+    <defaultValue>4</defaultValue>
+    <description>Month number that board member terms are valid until, where 1 is January and 12 is December.</description>
     <externalId>false</externalId>
-    <label>Vaccine Renewal Years</label>
+    <label>Board Term End Month</label>
     <precision>2</precision>
-    <required>false</required>
+    <required>true</required>
     <scale>0</scale>
     <trackTrending>false</trackTrending>
     <type>Number</type>

--- a/force-app/main/default/objects/AtlasSettings__c/fields/RabiesRenewalYears__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/RabiesRenewalYears__c.field-meta.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RabiesRenewalYears__c</fullName>
     <defaultValue>3</defaultValue>
-    <description
-    >Years before a rabies vaccine needs to be renewed.</description>
+    <description>Years before a rabies vaccine needs to be renewed.</description>
     <externalId>false</externalId>
     <label>Rabies Renewal Years</label>
     <precision>2</precision>

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -35,17 +35,10 @@ trigger ContactTrigger on Contact (before insert, before update) {
         if (newContact.LastBoardTermStartDate__c != null) {
             integer month = newContact.LastBoardTermStartDate__c.month();
             Date minTerm = newContact.LastBoardTermStartDate__c.addYears(3);
-            integer months = 0;
-            if (month < 6) {
-                months = 6 - month;
-            }
-            else if (month > 6) {
-                months = 18 - month;
-            }
-            // We want to wind up at the last day of June in the year following 3 years of service.
-            // So, months + 1 takes us to July, toStartOfMonth() takes us to July 1, and subtracting
-            // a day takes us to June 30.
-            newContact.BoardTermValidUntil__c = minTerm.addMonths(months + 1).toStartOfMonth().addDays(-1);
+            // We want to wind up at the last day of the month following 3 years of service.
+            // So, months + 1 takes us to the next month, toStartOfMonth() takes us to the first day of the month, and subtracting
+            // a day takes us back to the last day of the month they started in.
+            newContact.BoardTermValidUntil__c = minTerm.addMonths(1).toStartOfMonth().addDays(-1);
         }
     }
 }

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -37,19 +37,20 @@ trigger ContactTrigger on Contact (before insert, before update) {
         if (newContact.LastBoardTermStartDate__c != null && newContact.LastBoardTermStartDate__c != oldBoardDate) {
             AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
             // check to see if settings are missing
-            if (settings.BoardTermEndMonth__c == 0) {
+            if (settings.BoardTermEndMonth__c == null) {
                 settings = new AtlasSettings__c();
-                insert settings;
+                upsert settings;
+                settings = AtlasSettings__c.getOrgDefaults();
             }
-            final Integer endMonth = (Integer)settings.BoardTermEndMonth__c;
+            Integer endMonth = (Integer)settings.BoardTermEndMonth__c;
             integer month = newContact.LastBoardTermStartDate__c.month();
             Date minTerm = newContact.LastBoardTermStartDate__c.addYears(3);
             integer months = 0;
-            if (month < 6) {
-                months = 6 - month;
+            if (month < endMonth) {
+                months = endMonth - month;
             }
-            else if (month > 6) {
-                months = 18 - month;
+            else if (month > endMonth) {
+                months = 12 + endMonth - month;
             }
             // We want to wind up at the last day of June in the year following 3 years of service.
             // So, months + 1 takes us to July, toStartOfMonth() takes us to July 1, and subtracting

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -61,11 +61,11 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(Date.newInstance(2026, 1, 31), saved.BoardTermValidUntil__c);
+        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
     }
 
     @isTest
-    static void update_setsBoardTermEnd_whenStartJune() {
+    static void update_setsBoardTermEnd_whenStartInEndMonth() {
         Contact joe = new Contact(
             Email = 'joe-blow@pump.com',
             FirstName = 'Joe',
@@ -74,7 +74,7 @@ public with sharing class TestContactTrigger {
         );
         insert joe;
 
-        Date start = Date.newInstance(2023, 6, 6);
+        Date start = Date.newInstance(2023, 4, 30);
         joe.LastBoardTermStartDate__c = start;
 
         // Act
@@ -86,7 +86,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(Date.newInstance(2026, 6, 30), saved.BoardTermValidUntil__c);
+        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
     }
 
     @isTest
@@ -111,7 +111,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(Date.newInstance(2025, 7, 31), saved.BoardTermValidUntil__c);
+        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
     }
 
     @isTest
@@ -136,6 +136,6 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(Date.newInstance(2025, 12, 31), saved.BoardTermValidUntil__c);
+        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
     }
 }

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -61,7 +61,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 1, 31), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -74,7 +74,7 @@ public with sharing class TestContactTrigger {
         );
         insert joe;
 
-        Date start = Date.newInstance(2023, 6, 30);
+        Date start = Date.newInstance(2023, 6, 6);
         joe.LastBoardTermStartDate__c = start;
 
         // Act
@@ -86,7 +86,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 6, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -111,7 +111,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2025, 7, 31), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -136,6 +136,6 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2025, 12, 31), saved.BoardTermValidUntil__c);
     }
 }

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -61,7 +61,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -86,7 +86,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -111,7 +111,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -136,6 +136,6 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 4, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 }


### PR DESCRIPTION
To last day of the month 3 years after the start date



# Critical Changes

# Changes

Change calculation for board term valid until logic to last day of month 3 years after the start date.

# Issues Closed
