### PR TITLE
Added a new field

### DIFF
--- a/force-app/main/default/layouts/Team__c-Team Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Team__c-Team Layout.layout-meta.xml
@@ -39,6 +39,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>TrainingStartDate__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>PatCount__c</field>
             </layoutItems>
             <layoutItems>
@@ -164,7 +168,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8F000001Lj5L</masterLabel>
+        <masterLabel>00hRt000000D4E4</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Team__c/fields/TrainingStartDate__c.field-meta.xml
+++ b/force-app/main/default/objects/Team__c/fields/TrainingStartDate__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TrainingStartDate__c</fullName>
+    <externalId>false</externalId>
+    <inlineHelpText>The date when Team Training actually starts.</inlineHelpText>
+    <label>Training Start Date</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
@@ -89,11 +89,6 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
-        <field>CategoryRule__c.Group__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
         <editable>true</editable>
         <field>CategoryRule__c.Position__c</field>
         <readable>true</readable>
@@ -1036,6 +1031,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Team__c.Status__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Team__c.TrainingStartDate__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/AtlasTeam.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasTeam.permissionset-meta.xml
@@ -563,6 +563,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Team__c.TrainingStartDate__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Team__c.XrayReceived__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes

- Created the "Training Start Date" custom field on Team object and located in the correct position in the team layout. 
- Added the permission set to view and edit the field for Altas Super Users and Atlas Teams.

# Issues Closed

#497 
