### PR TITLE
Added the checkbox Text Messages Approved

### DIFF
--- a/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Contact-Atlas Contact Layout.layout-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
-    <excludeButtons>RequestUseSfdc</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
@@ -92,6 +91,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>npsp__Do_Not_Contact__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>TextMessagesApproved__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -357,7 +360,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hE2000000vJ9M</masterLabel>
+        <masterLabel>00hRt000000D4E5</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Contact/fields/TextMessagesApproved__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/TextMessagesApproved__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TextMessagesApproved__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Text Messages Approved</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/AtlasBase.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasBase.permissionset-meta.xml
@@ -164,6 +164,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Contact.TextMessagesApproved__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Contact.npe01__AlternateEmail__c</field>
         <readable>true</readable>

--- a/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasSuperUser.permissionset-meta.xml
@@ -89,11 +89,6 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
-        <field>CategoryRule__c.Group__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
         <editable>true</editable>
         <field>CategoryRule__c.Position__c</field>
         <readable>true</readable>
@@ -556,6 +551,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Contact.SystemAccess__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Contact.TextMessagesApproved__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes

- Added the checkbox Text Messages Approved to Contacts object. 
- Located in the Atlas Contact Layout.
- Added the permission set to view/edit the Text Messages Approved field for Atlas Super Users and Atlas Base

# Issues Closed

#498
