### PR TITLE
Restored change for board term end month

### DIFF
--- a/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/BoardTermEndMonth__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BoardTermEndMonth__c</fullName>
+    <defaultValue>4</defaultValue>
+    <description>The number for the month a Board Member&apos;s term will end in, such as 1 for January, or 6 for June.  Use 0 if the term will end at the end of the month 3 years after the start date.</description>
+    <externalId>false</externalId>
+    <label>Board Term End Month</label>
+    <precision>2</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -5,12 +5,14 @@ trigger ContactTrigger on Contact (before insert, before update) {
         string oldEmail = newContact.Email;
         string oldPhone = newContact.Phone;
         string oldPositions = null;
+        Date oldBoardDate = null;
         if (Trigger.isUpdate) {
             //Get Old Value
             Contact oldContact = trigger.oldMap.get(newContact.Id);
             oldEmail = oldContact.Email;
             oldPhone = oldContact.Phone;
             oldPositions = oldContact.Positions__c;
+            oldBoardDate = oldContact.LastBoardTermStartDate__c;
         }
         
         // Check if Contact is set
@@ -36,15 +38,23 @@ trigger ContactTrigger on Contact (before insert, before update) {
         }
 
         // Set BoardTermValidUntil
-        if (newContact.LastBoardTermStartDate__c != null) {
+        if (newContact.LastBoardTermStartDate__c != null && newContact.LastBoardTermStartDate__c != oldBoardDate) {
+            AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+            // check to see if settings are missing
+            if (settings.BoardTermEndMonth__c == null) {
+                settings = new AtlasSettings__c();
+                upsert settings;
+                settings = AtlasSettings__c.getOrgDefaults();
+            }
+            Integer endMonth = (Integer)settings.BoardTermEndMonth__c;
             integer month = newContact.LastBoardTermStartDate__c.month();
             Date minTerm = newContact.LastBoardTermStartDate__c.addYears(3);
             integer months = 0;
-            if (month < 6) {
-                months = 6 - month;
+            if (month < endMonth) {
+                months = endMonth - month;
             }
-            else if (month > 6) {
-                months = 18 - month;
+            else if (month > endMonth && endMonth > 0) {
+                months = 12 + endMonth - month;
             }
             // We want to wind up at the last day of June in the year following 3 years of service.
             // So, months + 1 takes us to July, toStartOfMonth() takes us to July 1, and subtracting

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -61,11 +61,11 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
-    static void update_setsBoardTermEnd_whenStartJune() {
+    static void update_setsBoardTermEnd_whenStartInEndMonth() {
         Contact joe = new Contact(
             Email = 'joe-blow@pump.com',
             FirstName = 'Joe',
@@ -74,7 +74,7 @@ public with sharing class TestContactTrigger {
         );
         insert joe;
 
-        Date start = Date.newInstance(2023, 6, 30);
+        Date start = Date.newInstance(2023, 4, 30);
         joe.LastBoardTermStartDate__c = start;
 
         // Act
@@ -86,7 +86,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -111,7 +111,7 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
     }
 
     @isTest
@@ -136,6 +136,64 @@ public with sharing class TestContactTrigger {
         System.assert(result.isSuccess());
         Contact saved = getContact(result.getId());
         System.assert(result.getErrors().size() == 0);
-        System.assertEquals(saved.BoardTermValidUntil__c, Date.newInstance(2026, 6, 30));
+        System.assertEquals(Date.newInstance(2026, 4, 30), saved.BoardTermValidUntil__c);
+    }
+
+    @isTest
+    static void update_setsBoardTermEnd_whenEndMonth0() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        settings.BoardTermEndMonth__c = 0;
+        upsert settings;
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            LastBoardTermStartDate__c = null
+        );
+        insert joe;
+
+        Date start = Date.newInstance(2022, 12, 25);
+        joe.LastBoardTermStartDate__c = start;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, false);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = getContact(result.getId());
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(Date.newInstance(2025, 12, 31), saved.BoardTermValidUntil__c);
+    }
+
+    @isTest
+    static void update_setsBoardTermEnd_whenEndMonth6() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        settings.BoardTermEndMonth__c = 6;
+        upsert settings;
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            LastBoardTermStartDate__c = null
+        );
+        insert joe;
+
+        Date start = Date.newInstance(2022, 12, 25);
+        joe.LastBoardTermStartDate__c = start;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, false);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = getContact(result.getId());
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(Date.newInstance(2026, 6, 30), saved.BoardTermValidUntil__c);
     }
 }


### PR DESCRIPTION

# Critical Changes

# Changes

1. Added option for ending the same month as the member started.
2. Added unit tests

# Issues Closed
486