### PR TITLE
Feature/545 add field for firstaidvaliduntil

### DIFF
--- a/force-app/main/default/classes/ClearDateService.cls
+++ b/force-app/main/default/classes/ClearDateService.cls
@@ -22,13 +22,13 @@ public with sharing class ClearDateService {
             SELECT Id,
                 ADSiMApplicationReceived__c, ADSiMPreApplicationReceived__c, ADSiMProgAgreementReceived__c,
 				BoardAgreementReceived__c, BoardApplicationReceived__c, BoardCoIReceived__c, BoardResumeReceived__c, BoardToNReceived__c,
-				FacilitatorApplicationReceived__c, FacilitatorCertAgreementReceived__c, FacilitatorFirstAidReceived__c, FacilitatorInfrNoticeReceived__c, FacilitatorPracticumReceived__c, FacilitatorProgAgreementReceived__c, FacilitatorReferenceReceived__c,
+				FacilitatorApplicationReceived__c, FacilitatorCertAgreementReceived__c, FacilitatorInfrNoticeReceived__c, FacilitatorPracticumReceived__c, FacilitatorProgAgreementReceived__c, FacilitatorReferenceReceived__c,
+				ContactFormReceived__c, FirstAidReceived__c,
 				PuppyApplicationReceived__c, PuppyCertAgreementReceived__c, PuppyContractReceived__c, PuppyInfrNoticeReceived__c, PuppyProgAgreementReceived__c, PuppyReferenceReceived__c,
-				StaffAgreementReceived__c, StaffApplicationReceived__c, StaffFirstAidReceived__c, StaffI9Received__c, StaffOfferReceived__c, StaffResumeReceived__c, StaffW4Received__c, StaffW9Received__c,
+				StaffAgreementReceived__c, StaffApplicationReceived__c, StaffI9Received__c, StaffOfferReceived__c, StaffResumeReceived__c, StaffW4Received__c, StaffW9Received__c,
 				StandaloneApplicationReceived__c, StandaloneProgAgreementReceived__c,
 				TrainerApplicationReceived__c, TrainerCertAgreementReceived__c, TrainerClientReferenceReceived__c, TrainerInfrNoticeReceived__c, TrainerProfReferenceReceived__c, TrainerProgAgreementReceived__c,
-				VolunteerAgreementReceived__c, VolunteerApplicationReceived__c, VolunteerResumeReceived__c,
-				ContactFormReceived__c
+				VolunteerAgreementReceived__c, VolunteerApplicationReceived__c, VolunteerResumeReceived__c
             FROM Contact
             WHERE Id = :recordId];
 
@@ -46,6 +46,10 @@ public with sharing class ClearDateService {
         
         if (cv.Category__c == 'Facilitator') {
             clearFacilitatorDate(cv, contact);
+        }
+        
+        if (cv.Category__c == 'Na') {
+            clearNaDate(cv, contact);
         }
         
         if (cv.Category__c == 'Puppy') {
@@ -68,9 +72,6 @@ public with sharing class ClearDateService {
             clearVolunteerDate(cv, contact);
         }
 
-        if (cv.Type__c == 'ContactForm'){
-            contact.ContactFormReceived__c = null;
-        }
         update contact;
     }
 
@@ -122,10 +123,6 @@ public with sharing class ClearDateService {
             contact.FacilitatorCertAgreementReceived__c = null;
         }
 
-        if (cv.Type__c == 'FirstAid'){
-            contact.FacilitatorFirstAidReceived__c = null;
-        }
-
         if (cv.Type__c == 'InfrNotice'){
             contact.FacilitatorInfrNoticeReceived__c = null;
         }
@@ -140,6 +137,17 @@ public with sharing class ClearDateService {
 
         if (cv.Type__c == 'Reference'){
             contact.FacilitatorReferenceReceived__c = null;
+        }
+    }
+
+    // Clear the last date when the category is Na
+    private static void clearNaDate(ContentVersion cv, Contact contact) {
+        if (cv.Type__c == 'ContactForm'){
+            contact.ContactFormReceived__c = null;
+        }
+
+        if (cv.Type__c == 'FirstAid'){
+            contact.FirstAidReceived__c = null;
         }
     }
 
@@ -178,10 +186,6 @@ public with sharing class ClearDateService {
 
         if (cv.Type__c == 'Application'){
             contact.StaffApplicationReceived__c = null;
-        }
-
-        if (cv.Type__c == 'FirstAid'){
-            contact.StaffFirstAidReceived__c = null;
         }
 
         if (cv.Type__c == 'I9'){

--- a/force-app/main/default/classes/ContactService.cls
+++ b/force-app/main/default/classes/ContactService.cls
@@ -137,7 +137,10 @@ public with sharing class ContactService {
 
     // Share the contact with the appropriate groups based on which positions they have,
     // and the positions they are emergency contacts for
-    public static Contact shareContactBasedOnPositions(Contact person, Map<String, String> positionGroups) {
+    public static Contact shareContactBasedOnPositions(
+        Contact person,
+        Map<String, String> positionGroups
+    ) {
         // Create a set of the positions the user currently has
         Set<String> positions = new Set<String>();
         if (!String.isBlank(person.Positions__c)) {
@@ -188,7 +191,7 @@ public with sharing class ContactService {
         List<CategoryRule__c> rules = [
             SELECT GroupName__c, Position__c
             FROM CategoryRule__c
-            WHERE Position__c != null
+            WHERE Position__c != NULL
         ];
         Map<String, String> groupNames = new Map<String, String>();
         for (CategoryRule__c rule : rules) {
@@ -204,7 +207,9 @@ public with sharing class ContactService {
         contact.ShareBoard__c = groupNames.contains('Board');
         contact.SharePuppyRaiser__c = groupNames.contains('Puppy Raiser');
         contact.ShareStaff__c = groupNames.contains('Staff');
-        contact.ShareStandalonePrograms__c = groupNames.contains('Standalone Programs');
+        contact.ShareStandalonePrograms__c = groupNames.contains(
+            'Standalone Programs'
+        );
         contact.ShareTeam__c = groupNames.contains('Team');
         contact.ShareTrainer__c = groupNames.contains('Trainer');
         contact.ShareVolunteer__c = groupNames.contains('Volunteer');
@@ -213,10 +218,33 @@ public with sharing class ContactService {
 
     public static void setSharingFields() {
         List<Contact> contacts = [
-            SELECT IsBoardMember__c, IsClient__c, IsPuppyRaiser__c, IsStaff__c, IsStandalone__c, IsTeamFacilitator__c, IsTrainer__c, IsVolunteer__c,
-                    ShareBoard__c, SharePuppyRaiser__c, ShareStaff__c, ShareStandalonePrograms__c, ShareTeam__c, ShareTrainer__c, ShareVolunteer__c
+            SELECT
+                IsBoardMember__c,
+                IsClient__c,
+                IsPuppyRaiser__c,
+                IsStaff__c,
+                IsStandalone__c,
+                IsTeamFacilitator__c,
+                IsTrainer__c,
+                IsVolunteer__c,
+                ShareBoard__c,
+                SharePuppyRaiser__c,
+                ShareStaff__c,
+                ShareStandalonePrograms__c,
+                ShareTeam__c,
+                ShareTrainer__c,
+                ShareVolunteer__c
             FROM Contact
-            WHERE IsBoardMember__c = TRUE OR IsClient__c = TRUE OR IsPuppyRaiser__c = TRUE OR IsStaff__c = TRUE OR IsStandalone__c = TRUE OR IsTeamFacilitator__c = TRUE OR IsTrainer__c = TRUE OR IsVolunteer__c = TRUE];
+            WHERE
+                IsBoardMember__c = TRUE
+                OR IsClient__c = TRUE
+                OR IsPuppyRaiser__c = TRUE
+                OR IsStaff__c = TRUE
+                OR IsStandalone__c = TRUE
+                OR IsTeamFacilitator__c = TRUE
+                OR IsTrainer__c = TRUE
+                OR IsVolunteer__c = TRUE
+        ];
 
         Map<Id, Contact> contactMap = new Map<Id, Contact>();
 
@@ -225,7 +253,8 @@ public with sharing class ContactService {
             person.SharePuppyRaiser__c = person.IsPuppyRaiser__c;
             person.ShareStaff__c = person.IsStaff__c;
             person.ShareStandalonePrograms__c = person.IsStandalone__c;
-            person.ShareTeam__c = person.IsClient__c || person.IsTeamFacilitator__c;
+            person.ShareTeam__c =
+                person.IsClient__c || person.IsTeamFacilitator__c;
             person.ShareTrainer__c = person.IsTrainer__c;
             person.ShareVolunteer__c = person.IsVolunteer__c;
             contactMap.put(person.Id, person);
@@ -259,16 +288,79 @@ public with sharing class ContactService {
                 share = relation.npe4__RelatedContact__r;
             }
             share.ShareBoard__c = share.ShareBoard__c || shared.ShareBoard__c;
-            share.SharePuppyRaiser__c = share.SharePuppyRaiser__c || shared.SharePuppyRaiser__c;
+            share.SharePuppyRaiser__c =
+                share.SharePuppyRaiser__c || shared.SharePuppyRaiser__c;
             share.ShareStaff__c = share.ShareStaff__c || share.ShareStaff__c;
-            share.ShareStandalonePrograms__c = share.ShareStandalonePrograms__c || shared.ShareStandalonePrograms__c;
+            share.ShareStandalonePrograms__c =
+                share.ShareStandalonePrograms__c ||
+                shared.ShareStandalonePrograms__c;
             share.ShareTeam__c = share.ShareTeam__c || shared.ShareTeam__c;
-            share.ShareTrainer__c = share.ShareTrainer__c || shared.ShareTrainer__c;
-            share.ShareVolunteer__c = share.ShareVolunteer__c || shared.ShareVolunteer__c;
+            share.ShareTrainer__c =
+                share.ShareTrainer__c || shared.ShareTrainer__c;
+            share.ShareVolunteer__c =
+                share.ShareVolunteer__c || shared.ShareVolunteer__c;
             if (!contactMap.containsKey(relation.npe4__RelatedContact__c)) {
                 contactMap.put(relation.npe4__RelatedContact__c, share);
             }
         }
         update contactMap.values();
+    }
+
+    public static void setBoardTermValidUntil(
+        Contact newContact,
+        Date oldBoardDate
+    ) {
+        if (
+            newContact.LastBoardTermStartDate__c != null &&
+            newContact.LastBoardTermStartDate__c != oldBoardDate
+        ) {
+            AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+            // check to see if settings are missing
+            if (settings.BoardTermEndMonth__c == null) {
+                // TODO: get default value
+                settings.BoardTermEndMonth__c = 4;
+                upsert settings;
+            }
+            Integer endMonth = (Integer) settings.BoardTermEndMonth__c;
+            integer month = newContact.LastBoardTermStartDate__c.month();
+            Date minTerm = newContact.LastBoardTermStartDate__c.addYears(3);
+            integer months = 0;
+            if (month < endMonth) {
+                months = endMonth - month;
+            } else if (month > endMonth && endMonth > 0) {
+                months = 12 + endMonth - month;
+            }
+            // We want to wind up at the last day of June in the year following 3 years of service.
+            // So, months + 1 takes us to July, toStartOfMonth() takes us to July 1, and subtracting
+            // a day takes us to June 30.
+            newContact.BoardTermValidUntil__c = minTerm.addMonths(months + 1)
+                .toStartOfMonth()
+                .addDays(-1);
+        }
+    }
+
+    public static void updateFirstAidValidUntil(
+        Contact newContact,
+        Date oldFirstAidDate
+    ) {
+        if (newContact.FirstAidReceived__c == null) {
+            newContact.FirstAidValidUntil__c = null;
+            return;
+        }
+        if (
+            newContact.FirstAidReceived__c != null &&
+            newContact.FirstAidReceived__c != oldFirstAidDate
+        ) {
+            AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+            // check to see if settings are missing
+            if (settings.FirstAidRenewalYears__c == null) {
+                // TODO: get default value
+                settings.FirstAidRenewalYears__c = 2;
+                upsert settings;
+            }
+            newContact.FirstAidValidUntil__c = newContact.FirstAidReceived__c.addYears(
+                (integer) settings.FirstAidRenewalYears__c
+            );
+        }
     }
 }

--- a/force-app/main/default/classes/FileService.cls
+++ b/force-app/main/default/classes/FileService.cls
@@ -205,13 +205,13 @@ public with sharing class FileService {
             SELECT Id,
                 ADSiMApplicationReceived__c, ADSiMPreApplicationReceived__c, ADSiMProgAgreementReceived__c,
 				BoardAgreementReceived__c, BoardApplicationReceived__c, BoardCoIReceived__c, BoardResumeReceived__c, BoardToNReceived__c,
-				FacilitatorApplicationReceived__c, FacilitatorCertAgreementReceived__c, FacilitatorFirstAidReceived__c, FacilitatorInfrNoticeReceived__c, FacilitatorPracticumReceived__c, FacilitatorProgAgreementReceived__c, FacilitatorReferenceReceived__c,
+				FacilitatorApplicationReceived__c, FacilitatorCertAgreementReceived__c, FacilitatorInfrNoticeReceived__c, FacilitatorPracticumReceived__c, FacilitatorProgAgreementReceived__c, FacilitatorReferenceReceived__c,
+				ContactFormReceived__c, FirstAidReceived__c,
 				PuppyApplicationReceived__c, PuppyCertAgreementReceived__c, PuppyContractReceived__c, PuppyInfrNoticeReceived__c, PuppyProgAgreementReceived__c, PuppyReferenceReceived__c,
-				StaffAgreementReceived__c, StaffApplicationReceived__c, StaffFirstAidReceived__c, StaffI9Received__c, StaffOfferReceived__c, StaffResumeReceived__c, StaffW4Received__c, StaffW9Received__c,
+				StaffAgreementReceived__c, StaffApplicationReceived__c, StaffI9Received__c, StaffOfferReceived__c, StaffResumeReceived__c, StaffW4Received__c, StaffW9Received__c,
 				StandaloneApplicationReceived__c, StandaloneProgAgreementReceived__c,
 				TrainerApplicationReceived__c, TrainerCertAgreementReceived__c, TrainerClientReferenceReceived__c, TrainerInfrNoticeReceived__c, TrainerProfReferenceReceived__c, TrainerProgAgreementReceived__c,
-				VolunteerAgreementReceived__c, VolunteerApplicationReceived__c, VolunteerResumeReceived__c,
-				ContactFormReceived__c
+				VolunteerAgreementReceived__c, VolunteerApplicationReceived__c, VolunteerResumeReceived__c
             FROM Contact
             WHERE Id = :recordId
         ];
@@ -240,6 +240,10 @@ public with sharing class FileService {
                 updateFacilitatorDate(cv, contact);
             }
         
+            if (cv.Category__c == 'Na') {
+                updateNaDate(cv, contact);
+            }
+        
             if (cv.Category__c == 'Puppy') {
                 updatePuppyDate(cv, contact);
             }
@@ -258,10 +262,6 @@ public with sharing class FileService {
         
             if (cv.Category__c == 'Volunteer') {
                 updateVolunteerDate(cv, contact);
-            }
-
-            if (cv.Type__c == 'ContactForm' && isLater(contact.ContactFormReceived__c, cv.Date__c)) {
-                contact.ContactFormReceived__c = cv.Date__c;
             }
         }
         update contact;
@@ -318,10 +318,6 @@ public with sharing class FileService {
             contact.FacilitatorCertAgreementReceived__c = cv.Date__c;
         }
 
-        if (cv.Type__c == 'FirstAid' && isLater(contact.FacilitatorFirstAidReceived__c, cv.Date__c)) {
-            contact.FacilitatorFirstAidReceived__c = cv.Date__c;
-        }
-
         if (cv.Type__c == 'InfrNotice' && isLater(contact.FacilitatorInfrNoticeReceived__c, cv.Date__c)) {
             contact.FacilitatorInfrNoticeReceived__c = cv.Date__c;
         }
@@ -336,6 +332,18 @@ public with sharing class FileService {
 
         if (cv.Type__c == 'Reference' && isLater(contact.FacilitatorReferenceReceived__c, cv.Date__c)) {
             contact.FacilitatorReferenceReceived__c = cv.Date__c;
+        }
+    }
+
+    // Update the last date when the category is Na
+    private static void updateNaDate(ContentVersion cv, Contact contact) {
+
+        if (cv.Type__c == 'ContactForm' && isLater(contact.ContactFormReceived__c, cv.Date__c)) {
+            contact.ContactFormReceived__c = cv.Date__c;
+        }
+
+        if (cv.Type__c == 'FirstAid' && isLater(contact.FirstAidReceived__c, cv.Date__c)) {
+            contact.FirstAidReceived__c = cv.Date__c;
         }
     }
 
@@ -376,10 +384,6 @@ public with sharing class FileService {
 
         if (cv.Type__c == 'Application' && isLater(contact.StaffApplicationReceived__c, cv.Date__c)) {
             contact.StaffApplicationReceived__c = cv.Date__c;
-        }
-
-        if (cv.Type__c == 'FirstAid' && isLater(contact.StaffFirstAidReceived__c, cv.Date__c)) {
-            contact.StaffFirstAidReceived__c = cv.Date__c;
         }
 
         if (cv.Type__c == 'I9' && isLater(contact.StaffI9Received__c, cv.Date__c)) {

--- a/force-app/main/default/objects/AtlasSettings__c/fields/FirstAidRenewalYears__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/FirstAidRenewalYears__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FirstAidRenewalYears__c</fullName>
+    <defaultValue>2</defaultValue>
+    <description>Years between human First Aid Certificate renewals</description>
+    <externalId>false</externalId>
+    <label>First Aid Renewal Years</label>
+    <precision>2</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Contact/fields/FirstAidReceived__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/FirstAidReceived__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FirstAidReceived__c</fullName>
+    <description>The date the most recent version of First Aid Certification was uploaded</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set at the time of file upload. Do not edit directly.</inlineHelpText>
+    <label>Last First Aid Certificate</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/Contact/fields/FirstAidValidUntil__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/FirstAidValidUntil__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FirstAidValidUntil__c</fullName>
+    <description>The date the First Aid Certification is valid until</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set at the time of file upload. Do not edit directly.</inlineHelpText>
+    <label>First Aid Certificate Valid Until</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/ContentVersion/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/ContentVersion/fields/Type__c.field-meta.xml
@@ -193,8 +193,7 @@
             <valueName>W9</valueName>
         </valueSettings>
         <valueSettings>
-            <controllingFieldValue>Staff</controllingFieldValue>
-            <controllingFieldValue>Facilitator</controllingFieldValue>
+            <controllingFieldValue>Na</controllingFieldValue>
             <valueName>FirstAid</valueName>
         </valueSettings>
         <valueSettings>

--- a/force-app/main/default/permissionsets/AtlasBase.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasBase.permissionset-meta.xml
@@ -121,6 +121,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Contact.FirstAidReceived__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Contact.FirstAidValidUntil__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Contact.Language__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/AtlasFacilitator.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasFacilitator.permissionset-meta.xml
@@ -38,11 +38,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Contact.FacilitatorFirstAidReceived__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>Contact.FacilitatorInfrNoticeReceived__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/AtlasStaff.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AtlasStaff.permissionset-meta.xml
@@ -23,11 +23,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
-        <field>Contact.StaffFirstAidReceived__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
         <field>Contact.StaffI9Received__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/quickActions/Contact.Staff.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Contact.Staff.quickAction-meta.xml
@@ -48,11 +48,6 @@
                 <field>StaffW9Received__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>StaffFirstAidReceived__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>
     <type>Update</type>

--- a/force-app/main/default/quickActions/Contact.Staff.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Contact.Staff.quickAction-meta.xml
@@ -26,6 +26,11 @@
                 <field>StaffOfferReceived__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>FirstAidReceived__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
         </quickActionLayoutColumns>
         <quickActionLayoutColumns>
             <quickActionLayoutItems>
@@ -46,6 +51,11 @@
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>StaffW9Received__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>FirstAidValidUntil__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
         </quickActionLayoutColumns>

--- a/force-app/main/default/quickActions/Contact.TeamFacilitator.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Contact.TeamFacilitator.quickAction-meta.xml
@@ -62,6 +62,16 @@
                 <field>FacilitatorPracticumReceived__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>FirstAidReceived__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>FirstAidValidUntil__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>
     <type>Update</type>

--- a/force-app/main/default/quickActions/Contact.TeamFacilitator.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Contact.TeamFacilitator.quickAction-meta.xml
@@ -62,11 +62,6 @@
                 <field>FacilitatorPracticumReceived__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>FacilitatorFirstAidReceived__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>
     <type>Update</type>

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -6,6 +6,7 @@ trigger ContactTrigger on Contact (before insert, before update) {
         string oldPhone = newContact.Phone;
         string oldPositions = null;
         Date oldBoardDate = null;
+        Date oldFirstAidDate = null;
         if (Trigger.isUpdate) {
             //Get Old Value
             Contact oldContact = trigger.oldMap.get(newContact.Id);
@@ -13,6 +14,7 @@ trigger ContactTrigger on Contact (before insert, before update) {
             oldPhone = oldContact.Phone;
             oldPositions = oldContact.Positions__c;
             oldBoardDate = oldContact.LastBoardTermStartDate__c;
+            oldFirstAidDate = oldContact.FirstAidReceived__c;
         }
         
         // Check if Contact is set
@@ -38,29 +40,7 @@ trigger ContactTrigger on Contact (before insert, before update) {
         }
 
         // Set BoardTermValidUntil
-        if (newContact.LastBoardTermStartDate__c != null && newContact.LastBoardTermStartDate__c != oldBoardDate) {
-            AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
-            // check to see if settings are missing
-            if (settings.BoardTermEndMonth__c == null) {
-                settings = new AtlasSettings__c();
-                upsert settings;
-                settings = AtlasSettings__c.getOrgDefaults();
-            }
-            Integer endMonth = (Integer)settings.BoardTermEndMonth__c;
-            integer month = newContact.LastBoardTermStartDate__c.month();
-            Date minTerm = newContact.LastBoardTermStartDate__c.addYears(3);
-            integer months = 0;
-            if (month < endMonth) {
-                months = endMonth - month;
-            }
-            else if (month > endMonth && endMonth > 0) {
-                months = 12 + endMonth - month;
-            }
-            // We want to wind up at the last day of June in the year following 3 years of service.
-            // So, months + 1 takes us to July, toStartOfMonth() takes us to July 1, and subtracting
-            // a day takes us to June 30.
-            newContact.BoardTermValidUntil__c = minTerm.addMonths(months + 1).toStartOfMonth().addDays(-1);
-        }
+        ContactService.setBoardTermValidUntil(newContact, oldBoardDate);
 
         // we've got the update going, so make sure UpdateForRelated__c is false
         newContact.UpdateForRelated__c = false;
@@ -73,6 +53,8 @@ trigger ContactTrigger on Contact (before insert, before update) {
                 modifiedContacts.put(newContact.Id, newContact);
             }
         }
+
+        ContactService.updateFirstAidValidUntil(newContact, oldFirstAidDate);
     }
 
     if (!Trigger.isInsert) {

--- a/force-app/main/test/TestClearDateServiceFacilitatorFields.cls
+++ b/force-app/main/test/TestClearDateServiceFacilitatorFields.cls
@@ -42,26 +42,6 @@ public with sharing class TestClearDateServiceFacilitatorFields {
     }
 
     @isTest
-    public static void clearDate_FacilitatorFirstAid_SetsDateToNull() {
-        ContentVersion cv = new ContentVersion(Category__c = 'Facilitator', Type__c = 'FirstAid');
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
-        insert record;
-        ClearDateService.clear(cv, record.Id);
-
-        record = [
-            SELECT FacilitatorFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            null,
-            record.FacilitatorFirstAidReceived__c,
-            'FacilitatorFirstAidReceived__c not cleared'
-        );
-    }
-
-    @isTest
     public static void clearDate_FacilitatorInfrNotice_SetsDateToNull() {
         ContentVersion cv = new ContentVersion(Category__c = 'Facilitator', Type__c = 'InfrNotice');
         Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');

--- a/force-app/main/test/TestClearDateServiceNaFields.cls
+++ b/force-app/main/test/TestClearDateServiceNaFields.cls
@@ -20,4 +20,24 @@ public with sharing class TestClearDateServiceNaFields {
             'ContactFormReceived__c not cleared'
         );
     }
+
+    @isTest
+    public static void clearDate_NaFirstAid_SetsDateToNull() {
+        ContentVersion cv = new ContentVersion(Category__c = 'Na', Type__c = 'FirstAid');
+        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
+        insert record;
+        ClearDateService.clear(cv, record.Id);
+
+        record = [
+            SELECT FirstAidReceived__c
+            FROM Contact
+            WHERE Id = :record.Id
+            LIMIT 1
+        ];
+        system.assertEquals(
+            null,
+            record.FirstAidReceived__c,
+            'FirstAidReceived__c not cleared'
+        );
+    }
 }

--- a/force-app/main/test/TestClearDateServiceStaffFields.cls
+++ b/force-app/main/test/TestClearDateServiceStaffFields.cls
@@ -42,26 +42,6 @@ public with sharing class TestClearDateServiceStaffFields {
     }
 
     @isTest
-    public static void clearDate_StaffFirstAid_SetsDateToNull() {
-        ContentVersion cv = new ContentVersion(Category__c = 'Staff', Type__c = 'FirstAid');
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
-        insert record;
-        ClearDateService.clear(cv, record.Id);
-
-        record = [
-            SELECT StaffFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            null,
-            record.StaffFirstAidReceived__c,
-            'StaffFirstAidReceived__c not cleared'
-        );
-    }
-
-    @isTest
     public static void clearDate_StaffI9_SetsDateToNull() {
         ContentVersion cv = new ContentVersion(Category__c = 'Staff', Type__c = 'I9');
         Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -196,4 +196,116 @@ public with sharing class TestContactTrigger {
         System.assert(result.getErrors().size() == 0);
         System.assertEquals(Date.newInstance(2026, 6, 30), saved.BoardTermValidUntil__c);
     }
+
+    @isTest
+    static void insert_setsFirstAidValidUntil_whenFirstAidSet() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            FirstAidReceived__c = received
+        );
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.insert(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, FirstAidValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(received.addYears(2), saved.FirstAidValidUntil__c);
+    }
+
+    @isTest
+    static void update_setsFirstAidValidUntil_whenFirstAidSet() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            FirstAidReceived__c = null,
+            FirstAidValidUntil__c = received
+        );
+        insert joe;
+
+        joe.FirstAidReceived__c = received;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, FirstAidValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(received.addYears(2), saved.FirstAidValidUntil__c);
+    }
+
+    @isTest
+    static void update_leavesFirstAidValidUntil_whenValidUntilSet() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            FirstAidReceived__c = received,
+            FirstAidValidUntil__c = received
+        );
+        insert joe;
+
+        Date expected = received.addYears(3);
+        joe.FirstAidValidUntil__c = expected;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, FirstAidValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(expected, saved.FirstAidValidUntil__c);
+    }
+
+    @isTest
+    static void update_leavesFirstAidValidUntil_whenReceivedNotSet() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            FirstAidReceived__c = received
+        );
+        insert joe;
+
+        joe.FirstAidReceived__c = null;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, FirstAidValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(null, saved.FirstAidValidUntil__c);
+    }
 }

--- a/force-app/main/test/TestFileServiceFacilitatorFields.cls
+++ b/force-app/main/test/TestFileServiceFacilitatorFields.cls
@@ -123,66 +123,6 @@ public with sharing class TestFileServiceFacilitatorFields {
     }
 
     @isTest
-    public static void updateDate_FacilitatorFirstAid_SetsDateWhenNull() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Facilitator', 'FirstAid', Date.today(), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT FacilitatorFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.FacilitatorFirstAidReceived__c,
-            'FacilitatorFirstAidReceived__c not set'
-        );
-    }
-
-    @isTest
-    public static void updateDate_FacilitatorFirstAid_SetsDateWhenNewer() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', FacilitatorFirstAidReceived__c = Date.today().addDays(-1));
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Facilitator', 'FirstAid', Date.today(), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT FacilitatorFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.FacilitatorFirstAidReceived__c,
-            'FacilitatorFirstAidReceived__c not set'
-        );
-    }
-
-    @isTest
-    public static void updateDate_FacilitatorFirstAid_LeavesDateWhenOlder() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', FacilitatorFirstAidReceived__c = Date.today());
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Facilitator', 'FirstAid', Date.today().addDays(-1), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT FacilitatorFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.FacilitatorFirstAidReceived__c,
-            'FacilitatorFirstAidReceived__c set to an older date'
-        );
-    }
-
-    @isTest
     public static void updateDate_FacilitatorInfrNotice_SetsDateWhenNull() {
         Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
         insert record;

--- a/force-app/main/test/TestFileServiceNaFields.cls
+++ b/force-app/main/test/TestFileServiceNaFields.cls
@@ -61,4 +61,64 @@ public with sharing class TestFileServiceNaFields {
             'ContactFormReceived__c set to an older date'
         );
     }
+
+    @isTest
+    public static void updateDate_NaFirstAid_SetsDateWhenNull() {
+        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
+        insert record;
+        ContentVersion cv = TestFileServiceFields.createLink('Na', 'FirstAid', Date.today(), record.Id);
+        FileService.updateDate(cv, record.Id);
+
+        record = [
+            SELECT FirstAidReceived__c
+            FROM Contact
+            WHERE Id = :record.Id
+            LIMIT 1
+        ];
+        system.assertEquals(
+            Date.today(),
+            record.FirstAidReceived__c,
+            'FirstAidReceived__c not set'
+        );
+    }
+
+    @isTest
+    public static void updateDate_NaFirstAid_SetsDateWhenNewer() {
+        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', FirstAidReceived__c = Date.today().addDays(-1));
+        insert record;
+        ContentVersion cv = TestFileServiceFields.createLink('Na', 'FirstAid', Date.today(), record.Id);
+        FileService.updateDate(cv, record.Id);
+
+        record = [
+            SELECT FirstAidReceived__c
+            FROM Contact
+            WHERE Id = :record.Id
+            LIMIT 1
+        ];
+        system.assertEquals(
+            Date.today(),
+            record.FirstAidReceived__c,
+            'FirstAidReceived__c not set'
+        );
+    }
+
+    @isTest
+    public static void updateDate_NaFirstAid_LeavesDateWhenOlder() {
+        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', FirstAidReceived__c = Date.today());
+        insert record;
+        ContentVersion cv = TestFileServiceFields.createLink('Na', 'FirstAid', Date.today().addDays(-1), record.Id);
+        FileService.updateDate(cv, record.Id);
+
+        record = [
+            SELECT FirstAidReceived__c
+            FROM Contact
+            WHERE Id = :record.Id
+            LIMIT 1
+        ];
+        system.assertEquals(
+            Date.today(),
+            record.FirstAidReceived__c,
+            'FirstAidReceived__c set to an older date'
+        );
+    }
 }

--- a/force-app/main/test/TestFileServiceStaffFields.cls
+++ b/force-app/main/test/TestFileServiceStaffFields.cls
@@ -123,66 +123,6 @@ public with sharing class TestFileServiceStaffFields {
     }
 
     @isTest
-    public static void updateDate_StaffFirstAid_SetsDateWhenNull() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Staff', 'FirstAid', Date.today(), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT StaffFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.StaffFirstAidReceived__c,
-            'StaffFirstAidReceived__c not set'
-        );
-    }
-
-    @isTest
-    public static void updateDate_StaffFirstAid_SetsDateWhenNewer() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', StaffFirstAidReceived__c = Date.today().addDays(-1));
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Staff', 'FirstAid', Date.today(), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT StaffFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.StaffFirstAidReceived__c,
-            'StaffFirstAidReceived__c not set'
-        );
-    }
-
-    @isTest
-    public static void updateDate_StaffFirstAid_LeavesDateWhenOlder() {
-        Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com', StaffFirstAidReceived__c = Date.today());
-        insert record;
-        ContentVersion cv = TestFileServiceFields.createLink('Staff', 'FirstAid', Date.today().addDays(-1), record.Id);
-        FileService.updateDate(cv, record.Id);
-
-        record = [
-            SELECT StaffFirstAidReceived__c
-            FROM Contact
-            WHERE Id = :record.Id
-            LIMIT 1
-        ];
-        system.assertEquals(
-            Date.today(),
-            record.StaffFirstAidReceived__c,
-            'StaffFirstAidReceived__c set to an older date'
-        );
-    }
-
-    @isTest
     public static void updateDate_StaffI9_SetsDateWhenNull() {
         Contact record = new Contact(FirstName = 'Test', LastName = 'Contact', Email = 'abc@abc.com');
         insert record;

--- a/scripts/python/generate_file_code/category.py
+++ b/scripts/python/generate_file_code/category.py
@@ -39,7 +39,7 @@ class Category:
     private static void update{category}Date(ContentVersion cv, {object} {name}) {{
 '''
         definition = template.format(category = self.category, object = self.object, name = self.name)
-        types = [typ.code() for typ in self.types if typ.doc_type != 'ContactForm']
+        types = [typ.code() for typ in self.types]
         end = '    }\n'
         return definition + ''.join(types) + end
 
@@ -49,7 +49,7 @@ class Category:
     // Clear the last date when the category is {category}
     private static void clear{category}Date(ContentVersion cv, {object} {name}) {{'''
         definition = template.format(category = self.category, object = self.object, name = self.name)
-        types = [typ.clear_code() for typ in self.types if typ.doc_type != 'ContactForm']
+        types = [typ.clear_code() for typ in self.types]
         end = '    }\n'
         return definition + ''.join(types) + end
 
@@ -65,7 +65,7 @@ class Category:
 
     def fields(self):
         '''Return the list of fields for this category'''
-        return [typ.field for typ in self.types if typ.doc_type != 'ContactForm']
+        return [typ.field for typ in self.types]
 
 
     def test(self, test_file):

--- a/scripts/python/generate_file_code/contact.py
+++ b/scripts/python/generate_file_code/contact.py
@@ -2,7 +2,7 @@ from category import Category
 import templates.clear as clear
 import templates.update as update
 
-skip_categories = {'Client', 'Na'}
+skip_categories = {'Client'}
 
 class Contact:
     '''Class to control writing out the generated FileService code for the contact objects'''
@@ -15,7 +15,6 @@ class Contact:
     def fields(self):
         '''List the fields'''
         fields = [', '.join(category.fields()) for category in self.sorted_categories if (category.category not in skip_categories)]
-        fields.append('ContactFormReceived__c')
         return ',\n\t\t\t\t'.join(fields)
 
 
@@ -23,14 +22,14 @@ class Contact:
         self.file.write(update.contact_code_start.format(fields = self.fields()))
         for category in self.sorted_categories:
             if (category.category in skip_categories):
-                continue;
+                continue
             self.file.write(category.check())
 
         self.file.write(update.contact_code_end)
 
         for category in self.sorted_categories:
             if (category.category in skip_categories):
-                continue;
+                continue
             self.file.write(category.method())
 
 

--- a/scripts/python/generate_file_code/templates/clear.py
+++ b/scripts/python/generate_file_code/templates/clear.py
@@ -14,9 +14,6 @@ contact_code_start = '''
 '''
 
 contact_code_end = '''
-        if (cv.Type__c == 'ContactForm'){
-            contact.ContactFormReceived__c = null;
-        }
         update contact;
     }
 '''

--- a/scripts/python/generate_file_code/templates/update.py
+++ b/scripts/python/generate_file_code/templates/update.py
@@ -27,11 +27,7 @@ contact_code_start = '''
 
         for (ContentVersion cv : cvs) {{'''
 
-contact_code_end = '''
-            if (cv.Type__c == 'ContactForm' && isLater(contact.ContactFormReceived__c, cv.Date__c)) {
-                contact.ContactFormReceived__c = cv.Date__c;
-            }
-        }
+contact_code_end = '''        }
         update contact;
     }
 '''

--- a/scripts/python/generate_file_code/type.py
+++ b/scripts/python/generate_file_code/type.py
@@ -34,7 +34,7 @@ class CategoryType:
                 self.fields = new_team
                 self.setup = update.test_team_setup
 
-        elif typ == 'ContactForm':
+        elif cat == 'Na':
             self.name = 'contact'
             self.field = typ + 'Received__c'
             self.object = 'Contact'


### PR DESCRIPTION

# Critical Changes

# Changes

1. Hid fields for StaffFirstAidReceived and FacilitatorFirstAidReceived
2. Added FirstAidReceived and FirstAidValidUntil
3. Updated python scripts to generate code for setting received field for FirstAid on category `N/A`
4. Added new fields to Atlas Base permission set
5. Added FirstAidCertYears to custom settings with default value of 2
6. Corrected logic for grabbing default value for new custom setting fields

# Issues Closed
#545