### PR TITLE
Feature/560 all related files on contact

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -63,7 +63,7 @@ flows:
             90:
                 task: assign_permission_sets
                 options:
-                    api_names: AtlasSuperUser
+                    api_names: AtlasBackgroundCheck,AtlasBase,AtlasBoard,AtlasDemographics,AtlasFacilitator,AtlasPuppyRaiser,AtlasStaff,AtlasStandalonePrograms,AtlasTeam,AtlasTrainer,AtlasVolunteer
 
     # Flow to deploy current source to a sandbox for dev or verification
     sandbox:

--- a/datasets/recipes/category-rules.recipe.yml
+++ b/datasets/recipes/category-rules.recipe.yml
@@ -47,6 +47,7 @@
     Category__c: 'Standalone'
     Object__c: 'Contact'
     Position__c: 'Standalone'
+    Group__c: 'Standalone Programs'
 
 - object: CategoryRule__c
   just_once: True

--- a/force-app/main/default/classes/CategoryRuleController.cls
+++ b/force-app/main/default/classes/CategoryRuleController.cls
@@ -23,12 +23,11 @@ global without sharing class CategoryRuleController {
     }
  
     global static Set<String> getAllowedCategoriesForObject(Id recordId) {
-        return new Set<String>();
+        return getAllowedCategoriesForObject(recordId, false);
     }
 
     public static Set<String> getAllowedCategoriesForObject(Id recordId, Boolean isUpload) {
         if (isUpload == null) isUpload = false;
-        System.debug(isUpload);
         string objLabel = recordId.getSObjectType().getDescribe().getLabel();
 
         List<String> groupNames = UserAccessService.GetGroupNames(UserInfo.getUserId());
@@ -45,13 +44,13 @@ global without sharing class CategoryRuleController {
             AND Object__c = :objLabel
             AND Category__c IN :allCategories
         ];
+
         for (CategoryRule__c rule: rules) {
-            System.debug(rule);
             if (((isUpload && rule.ReadOnly__c != true) || !isUpload) && rule.Category__c != null) {
                 categories.addAll(rule.Category__c.split(';'));
             }
         }
-        
+
         return categories;
     }
 
@@ -102,7 +101,6 @@ global without sharing class CategoryRuleController {
             entries.add(option);
         }
         entries.sort();
-        System.debug(entries);
         return entries;
     }
 }

--- a/force-app/main/default/classes/FileController.cls
+++ b/force-app/main/default/classes/FileController.cls
@@ -115,9 +115,7 @@ global inherited sharing class FileController {
             List<ContentVersion> files = [
                 SELECT Title, ContentDocumentId, Category__c, Type__c, Date__c
                 FROM ContentVersion
-                WHERE
-                    ContentDocumentId IN :lstConDocs
-                    AND FileType != 'SNOTE'
+                WHERE ContentDocumentId IN :lstConDocs AND FileType != 'SNOTE'
                 ORDER BY Date__c DESC
                 LIMIT :max
             ];
@@ -132,9 +130,7 @@ global inherited sharing class FileController {
             related.total = [
                 SELECT COUNT()
                 FROM ContentVersion
-                WHERE
-                    ContentDocumentId IN :lstConDocs
-                    AND FileType != 'SNOTE'
+                WHERE ContentDocumentId IN :lstConDocs AND FileType != 'SNOTE'
             ];
             return related;
         } else {
@@ -216,34 +212,30 @@ global inherited sharing class FileController {
         if (recordId == null) {
             throw new AuraHandledException('recordId must not be null');
         }
-        // get all, since we can't be sure how many will be filtered out
+        Set<String> allowedCategories = new Set<String>(
+            CategoryRuleController.getAllowedCategoriesForObject(recordId)
+        );
+        allowedCategories.add('');
         RelatedObjects allFiles = getAllRelatedFiles(recordId, 10000);
 
-        RelatedObjects objects = new RelatedObjects();
+        RelatedObjects related = new RelatedObjects();
 
         if (allFiles.total > 0) {
-            RelatedObjects related = new RelatedObjects();
-
-            // get a map of the category and type labels
-            Map<string, string> categoryEntries = FileController.getEntryMap(
-                ContentVersion.Category__c.getDescribe()
-            );
-            Map<string, string> typeEntries = FileController.getEntryMap(
-                ContentVersion.Type__c.getDescribe()
-            );
-            Set<String> allowedCategories = new Set<String>(CategoryRuleController.getAllowedCategoriesForUser());
-            allowedCategories.add('');
-            
             for (Object item : allFiles.items) {
-                FileInfo info = (FileInfo)item;
-                if (allowedCategories.contains(info.cv.Category__c) || info.cv.Category__c == null) {
-                    related.items.add(info);
+                FileInfo info = (FileInfo) item;
+                if (
+                    allowedCategories.contains(info.cv.Category__c) ||
+                    info.cv.Category__c == null
+                ) {
+                    if (related.total < max) {
+                        related.items.add(info);
+                    }
+                    related.total = related.total + 1;
                 }
             }
-            related.total = related.items.size();
             return related;
         } else {
-            return new RelatedObjects();
+            return related;
         }
     }
 }

--- a/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js
+++ b/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js
@@ -145,31 +145,19 @@ export default class RelatedFiles extends NavigationMixin(LightningElement) {
     sortDirection = "asc";
     sortedBy;
 
-    // Used to sort the columns
-    sortBy(field, reverse, primer) {
-        const key = primer
-            ? function (x) {
-                  return primer(x[field]);
-              }
-            : function (x) {
-                  return x[field];
-              };
-
-        return function (a, b) {
-            a = key(a);
-            b = key(b);
-            return reverse * ((a > b) - (b > a));
-        };
-    }
-
     handleSort(event) {
-        const { fieldName: sortedBy, sortDirection } = event.detail;
+        var fieldName = event.detail.fieldName;
+        var sortDirection = event.detail.sortDirection;
         const cloneData = [...this.data];
 
-        cloneData.sort(this.sortBy(sortedBy, sortDirection === "asc" ? 1 : -1));
+        cloneData.sort((a, b) => {
+            const x1 = a[fieldName] ?? '';
+            const x2 = b[fieldName] ?? '';
+            const asc = x1 > x2 ? 1 : x1 < x2 ? -1 : 0;
+            return sortDirection === "asc" ? asc : asc * -1});
         this.data = cloneData;
+        this.sortedBy = fieldName;
         this.sortDirection = sortDirection;
-        this.sortedBy = sortedBy;
     }
 
     handleRowAction(event) {

--- a/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js
+++ b/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js
@@ -48,6 +48,7 @@ export default class RelatedFiles extends NavigationMixin(LightningElement) {
     @api objectApiName;
     @api recordId;
     @api viewAll;
+    @api numRecords = 6;
     columns = COLS;
     relatedObject = CV_OBJECT;
     @track data;
@@ -75,7 +76,7 @@ export default class RelatedFiles extends NavigationMixin(LightningElement) {
  
     @api
     get max() {
-        return this.viewAll ? 10000 : 6;
+        return this.viewAll ? 10000 : this.numRecords;
     }
 
     bareData;

--- a/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js-meta.xml
+++ b/force-app/main/default/lwc/relatedFilesCmp/relatedFilesCmp.js-meta.xml
@@ -7,4 +7,9 @@
     <targets>
         <target>lightning__RecordPage</target>
     </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <property name="numRecords" type="Integer" label="Number of Records to Display" default="6" />
+        </targetConfig>
+    </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/relatedLogsCmp/relatedLogsCmp.js
+++ b/force-app/main/default/lwc/relatedLogsCmp/relatedLogsCmp.js
@@ -47,7 +47,7 @@ const COLS = {
     },
     team: {
         label: "Team",
-        fieldName: TEAM_FIELD.fieldApiName,
+        fieldName: "teamName",
         type: "button",
         typeAttributes: {
             name: "team",
@@ -59,7 +59,7 @@ const COLS = {
     },
     facilitator: {
         label: "Facilitator",
-        fieldName: FACILITATOR_FIELD.fieldApiName,
+        fieldName: "facilitatorName",
         type: "button",
         typeAttributes: {
             name: "facilitator",
@@ -71,7 +71,7 @@ const COLS = {
     },
     submitter: {
         label: "Submitter",
-        fieldName: SUBMITTER_FIELD.fieldApiName,
+        fieldName: "submitterName",
         type: "button",
         typeAttributes: {
             name: "submitter",
@@ -227,13 +227,17 @@ export default class RelatedLogsCmp extends NavigationMixin(LightningElement) {
     }
 
     handleSort(event) {
-        const { fieldName: sortedBy, sortDirection } = event.detail;
+        const { fieldName, sortDirection } = event.detail;
         const cloneData = [...this.data];
 
-        cloneData.sort(this.sortBy(sortedBy, sortDirection === "asc" ? 1 : -1));
+        cloneData.sort((a, b) => {
+            const x1 = a[fieldName] ?? '';
+            const x2 = b[fieldName] ?? '';
+            const asc = x1 > x2 ? 1 : x1 < x2 ? -1 : 0;
+            return sortDirection === "asc" ? asc : asc * -1});
         this.data = cloneData;
         this.sortDirection = sortDirection;
-        this.sortedBy = sortedBy;
+        this.sortedBy = fieldName;
     }
 
     handleRowAction(event) {

--- a/force-app/main/default/lwc/relatedLogsCmp/relatedLogsCmp.js
+++ b/force-app/main/default/lwc/relatedLogsCmp/relatedLogsCmp.js
@@ -209,23 +209,6 @@ export default class RelatedLogsCmp extends NavigationMixin(LightningElement) {
     sortDirection = "asc";
     sortedBy;
 
-    // Used to sort the 'Age' column
-    sortBy(field, reverse, primer) {
-        const key = primer
-            ? function (x) {
-                  return primer(x[field]);
-              }
-            : function (x) {
-                  return x[field];
-              };
-
-        return function (a, b) {
-            a = key(a);
-            b = key(b);
-            return reverse * ((a > b) - (b > a));
-        };
-    }
-
     handleSort(event) {
         const { fieldName, sortDirection } = event.detail;
         const cloneData = [...this.data];

--- a/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger
+++ b/force-app/main/default/triggers/ContentDocumentLinkTrigger.trigger
@@ -1,4 +1,6 @@
-trigger ContentDocumentLinkTrigger on ContentDocumentLink (after insert) {
-    // create list of documents
-    FileService.updateDates(Trigger.new);
+trigger ContentDocumentLinkTrigger on ContentDocumentLink(after insert) {
+    if (Trigger.new[0].ShareType != 'I') {
+        // create list of documents
+        FileService.updateDates(Trigger.new);
+    }
 }

--- a/force-app/main/default/triggers/ContentVersionTrigger.trigger
+++ b/force-app/main/default/triggers/ContentVersionTrigger.trigger
@@ -1,3 +1,10 @@
 trigger ContentVersionTrigger on ContentVersion (after update) {
-   FileService.updateDates(Trigger.new);
+   List<ContentVersion> changedDates = new List<ContentVersion>();
+   for (ContentVersion cv : Trigger.New) {
+      ContentVersion oldCv = Trigger.oldMap.get(cv.Id);
+      if (oldCv.Date__c != cv.Date__c || oldCv.Category__c != cv.Category__c || oldCv.Type__c != cv.Type__c) {
+         changedDates.add(cv);
+      }
+   }
+   FileService.updateDates(changedDates);
 }

--- a/force-app/main/test/TestFileController.cls
+++ b/force-app/main/test/TestFileController.cls
@@ -398,38 +398,6 @@ public with sharing class TestFileController {
         System.assertEquals(0, related.total);
     }
 
-    // This method is used to setup the getRelatedFilesWith... tests.  The file records have categories
-    // of Board, Staff, and Volunteer.
-    private static RelatedObjects getRelatedFilesWithGroups(string[] groups) {
-        TestUtilities.insertCategoryRules();
-
-        Contact ronan = new Contact(FirstName = 'Ronan', LastName = 'Dax', email='ronan@test.com',
-        Positions__c='Client;Volunteer;Trainer;Board Member');
-        insert ronan;
-
-        List<ContentVersion> documents = insertRecords();
-
-        // delete all but the first document
-        List<Id> ids = new List<Id>();
-        for (ContentVersion cv : documents) {
-            ids.add(cv.ContentDocumentId);
-        }
-
-        FileController.relateFiles(ids, ronan.Id);
-        User adminUser = TestUtilities.createUser('Standard User');
-        TestUtilities.addUserToGroups(adminUser, groups);
-        ronan.OwnerId = adminUser.Id;
-        update ronan;
-        RelatedObjects related;
-        Test.startTest();
-        System.runAs(new User(Id = adminUser.Id)) {
-            related = FileController.getRelatedFiles(ronan.Id, 6);
-        }
-        Test.stopTest();
-
-        return related;
-    }
-
     @isTest
     public static void relateFile_ThrowsException_WhenNullDocumentId() {
         Dog__c ace = new Dog__c(Name = 'Ace');
@@ -581,55 +549,5 @@ public with sharing class TestFileController {
             WHERE LinkedEntityId = :ace.Id
         ];
         System.assertEquals(docIds.size(), links.size());
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForAll() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Board', 'Volunteer', 'Trainer' });
-        System.assertEquals(3, related.items.size());
-        System.assertEquals(3, related.total);
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForBoard() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Board' });
-
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
-        System.assertEquals('Board', ((FileInfo)related.items[0]).category);
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForVolunteer() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Volunteer' });
-
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
-        System.assertEquals('Volunteer', ((FileInfo)related.items[0]).category);
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForStaff() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Trainer' });
-
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
-        System.assertEquals('Trainer', ((FileInfo)related.items[0]).category);
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForNone() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Team' });
-
-        System.assertEquals(0, related.items.size());
-        System.assertEquals(0, related.total);
-    }
-
-    @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForBoardTrainer() {
-        RelatedObjects related = getRelatedFilesWithGroups(new string[] { 'Board', 'Trainer' });
-
-        System.assertEquals(2, related.items.size());
-        System.assertEquals(2, related.total);
     }
 }

--- a/force-app/main/test/TestFileControllerRestrictions.cls
+++ b/force-app/main/test/TestFileControllerRestrictions.cls
@@ -1,0 +1,259 @@
+/**
+ * This class contains unit tests for validating the behavior of Apex classes
+ * and triggers.
+ *
+ * Unit tests are class methods that verify whether a particular piece
+ * of code is working properly. Unit test methods take no arguments,
+ * commit no data to the database, and are flagged with the testMethod
+ * keyword in the method definition.
+ *
+ * All test methods in an org are executed whenever Apex code is deployed
+ * to a production org to confirm correctness, ensure code
+ * coverage, and prevent regressions. All Apex classes are
+ * required to have at least 75% code coverage in order to be deployed
+ * to a production org. In addition, all triggers must have some code coverage.
+ *
+ * The @isTest class annotation indicates this class only contains test
+ * methods. Classes defined with the @isTest annotation do not count against
+ * the org size limit for all Apex scripts.
+ *
+ * See the Apex Language Reference for more information about Testing and Code Coverage.
+ */
+@isTest
+private class TestFileControllerRestrictions {
+    class MyPickListInfo {
+        public Boolean active;
+        public Boolean defaultValue;
+        public String label;
+        public String validFor;
+        public String value;
+    }
+    public static Map<String, List<String>> getCategoryTypeDependencies() {
+        Map<String, List<String>> controllingInfo = new Map<String, List<String>>();
+
+        Schema.SObjectType objType = Schema.getGlobalDescribe()
+            .get('ContentVersion');
+
+        Schema.DescribeSObjectResult describeResult = objType.getDescribe();
+        Schema.DescribeFieldResult controllingFieldInfo = describeResult.fields.getMap()
+            .get('Category__c')
+            .getDescribe();
+        Schema.DescribeFieldResult dependentFieldInfo = describeResult.fields.getMap()
+            .get('Type__c')
+            .getDescribe();
+
+        List<Schema.PicklistEntry> controllingValues = controllingFieldInfo.getPicklistValues();
+        List<Schema.PicklistEntry> dependentValues = dependentFieldInfo.getPicklistValues();
+
+        for (Schema.PicklistEntry currControllingValue : controllingValues) {
+            controllingInfo.put(
+                currControllingValue.getValue(),
+                new List<String>()
+            );
+        }
+
+        for (Schema.PicklistEntry currDependentValue : dependentValues) {
+            String jsonString = JSON.serialize(currDependentValue);
+
+            MyPickListInfo info = (MyPickListInfo) JSON.deserialize(
+                jsonString,
+                MyPickListInfo.class
+            );
+
+            String hexString = EncodingUtil.convertToHex(
+                    EncodingUtil.base64Decode(info.validFor)
+                )
+                .toUpperCase();
+
+            Integer baseCount = 0;
+
+            for (Integer curr : hexString.getChars()) {
+                Integer val = 0;
+
+                if (curr >= 65) {
+                    val = curr - 65 + 10;
+                } else {
+                    val = curr - 48;
+                }
+
+                if ((val & 8) == 8) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 0].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 4) == 4) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 1].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 2) == 2) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 2].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 1) == 1) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 3].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+
+                baseCount += 4;
+            }
+        }
+
+        return controllingInfo;
+    }
+    public static List<ContentVersion> insertRecords() {
+        // get a map of the category and type labels
+        Map<String, List<String>> allCategories = getCategoryTypeDependencies();
+        List<ContentVersion> documents = new List<ContentVersion>();
+        Integer count = 1;
+        for (String category : allCategories.keySet()) {
+            List<String> types = allCategories.get(category);
+            for (String docType : types) {
+                List<Object> parameters = new List<Object>{ count };
+                documents.add(
+                    new ContentVersion(
+                        Title = String.format('TestDocument{0}', parameters),
+                        PathOnClient = String.format(
+                            'TestDocument{0}.jpg',
+                            parameters
+                        ),
+                        Origin = 'H',
+                        VersionData = Blob.valueOf('Document Body'),
+                        Category__c = category,
+                        Type__c = docType,
+                        Date__c = Date.today().addDays(-count)
+                    )
+                );
+                count = count + 1;
+            }
+        }
+
+        insert documents;
+
+        // We need to do the query here to get the ContentDocumentId's
+        documents = [
+            SELECT
+                Id,
+                ContentDocumentId,
+                Title,
+                PathOnClient,
+                Origin,
+                VersionData,
+                Category__c,
+                Type__c,
+                Date__c
+            FROM ContentVersion
+        ];
+        return documents;
+    }
+
+    // This method is used to setup the getRelatedFilesWith... tests.  The file records have all category/type combinations
+    private static RelatedObjects getRelatedFilesWithGroups(string[] groups) {
+        TestUtilities.insertCategoryRules();
+
+        List<ContentVersion> documents = insertRecords();
+
+        // Get the ids of all these documents
+        List<Id> ids = new List<Id>();
+        for (ContentVersion cv : documents) {
+            ids.add(cv.ContentDocumentId);
+        }
+        Contact ronan = new Contact(
+            FirstName = 'Ronan',
+            LastName = 'Dax',
+            email = 'ronan@test.com',
+            Positions__c = 'Board Member;Client;Puppy Raiser;Standalone;Staff;Team Facilitator;Team Facilitator Lead;Trainer;Volunteer',
+            ShareBoard__c = true,
+            SharePuppyRaiser__c = true,
+            ShareStaff__c = true,
+            ShareStandalonePrograms__c = true,
+            ShareTeam__c = true,
+            ShareTrainer__c = true,
+            ShareVolunteer__c = true
+        );
+        insert ronan;
+        FileController.relateFiles(ids, ronan.Id);
+
+        User testUser = TestUtilities.createUser('Standard User');
+        TestUtilities.addUserToGroups(testUser, groups);
+        RelatedObjects related = new RelatedObjects();
+        Test.startTest();
+        System.runAs(new User(Id = testUser.Id)) {
+            related = FileController.getRelatedFiles(ronan.Id, 6);
+        }
+        Test.stopTest();
+
+        return related;
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForAll() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Board', 'Volunteer', 'Trainer' }
+        );
+        System.assert(related.items.size() < 6);
+        System.assertEquals(3, related.total);
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForBoard() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Board' }
+        );
+
+        System.assertEquals(1, related.items.size());
+        System.assertEquals(1, related.total);
+        System.assertEquals('Board', ((FileInfo) related.items[0]).category);
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForVolunteer() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Volunteer' }
+        );
+
+        System.assertEquals(1, related.items.size());
+        System.assertEquals(1, related.total);
+        System.assertEquals(
+            'Volunteer',
+            ((FileInfo) related.items[0]).category
+        );
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForStaff() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Trainer' }
+        );
+
+        System.assertEquals(1, related.items.size());
+        System.assertEquals(1, related.total);
+        System.assertEquals('Trainer', ((FileInfo) related.items[0]).category);
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForNone() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Team' }
+        );
+
+        System.assertEquals(0, related.items.size());
+        System.assertEquals(0, related.total);
+    }
+
+    @isTest
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForBoardTrainer() {
+        RelatedObjects related = getRelatedFilesWithGroups(
+            new List<string>{ 'Board', 'Trainer' }
+        );
+
+        System.assertEquals(2, related.items.size());
+        System.assertEquals(2, related.total);
+    }
+}

--- a/force-app/main/test/TestFileControllerRestrictions.cls
+++ b/force-app/main/test/TestFileControllerRestrictions.cls
@@ -21,95 +21,9 @@
  */
 @isTest
 private class TestFileControllerRestrictions {
-    class MyPickListInfo {
-        public Boolean active;
-        public Boolean defaultValue;
-        public String label;
-        public String validFor;
-        public String value;
-    }
-    public static Map<String, List<String>> getCategoryTypeDependencies() {
-        Map<String, List<String>> controllingInfo = new Map<String, List<String>>();
-
-        Schema.SObjectType objType = Schema.getGlobalDescribe()
-            .get('ContentVersion');
-
-        Schema.DescribeSObjectResult describeResult = objType.getDescribe();
-        Schema.DescribeFieldResult controllingFieldInfo = describeResult.fields.getMap()
-            .get('Category__c')
-            .getDescribe();
-        Schema.DescribeFieldResult dependentFieldInfo = describeResult.fields.getMap()
-            .get('Type__c')
-            .getDescribe();
-
-        List<Schema.PicklistEntry> controllingValues = controllingFieldInfo.getPicklistValues();
-        List<Schema.PicklistEntry> dependentValues = dependentFieldInfo.getPicklistValues();
-
-        for (Schema.PicklistEntry currControllingValue : controllingValues) {
-            controllingInfo.put(
-                currControllingValue.getValue(),
-                new List<String>()
-            );
-        }
-
-        for (Schema.PicklistEntry currDependentValue : dependentValues) {
-            String jsonString = JSON.serialize(currDependentValue);
-
-            MyPickListInfo info = (MyPickListInfo) JSON.deserialize(
-                jsonString,
-                MyPickListInfo.class
-            );
-
-            String hexString = EncodingUtil.convertToHex(
-                    EncodingUtil.base64Decode(info.validFor)
-                )
-                .toUpperCase();
-
-            Integer baseCount = 0;
-
-            for (Integer curr : hexString.getChars()) {
-                Integer val = 0;
-
-                if (curr >= 65) {
-                    val = curr - 65 + 10;
-                } else {
-                    val = curr - 48;
-                }
-
-                if ((val & 8) == 8) {
-                    controllingInfo.get(
-                            controllingValues[baseCount + 0].getValue()
-                        )
-                        .add(currDependentValue.getValue());
-                }
-                if ((val & 4) == 4) {
-                    controllingInfo.get(
-                            controllingValues[baseCount + 1].getValue()
-                        )
-                        .add(currDependentValue.getValue());
-                }
-                if ((val & 2) == 2) {
-                    controllingInfo.get(
-                            controllingValues[baseCount + 2].getValue()
-                        )
-                        .add(currDependentValue.getValue());
-                }
-                if ((val & 1) == 1) {
-                    controllingInfo.get(
-                            controllingValues[baseCount + 3].getValue()
-                        )
-                        .add(currDependentValue.getValue());
-                }
-
-                baseCount += 4;
-            }
-        }
-
-        return controllingInfo;
-    }
     public static List<ContentVersion> insertRecords() {
         // get a map of the category and type labels
-        Map<String, List<String>> allCategories = getCategoryTypeDependencies();
+        Map<String, List<String>> allCategories = TestUtilities.getCategoryTypeDependencies();
         List<ContentVersion> documents = new List<ContentVersion>();
         Integer count = 1;
         for (String category : allCategories.keySet()) {
@@ -180,7 +94,7 @@ private class TestFileControllerRestrictions {
         insert ronan;
         FileController.relateFiles(ids, ronan.Id);
 
-        User testUser = TestUtilities.createUser('Standard User');
+        User testUser = TestUtilities.createUser('System Administrator');
         TestUtilities.addUserToGroups(testUser, groups);
         RelatedObjects related = new RelatedObjects();
         Test.startTest();
@@ -193,12 +107,12 @@ private class TestFileControllerRestrictions {
     }
 
     @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForAll() {
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForBoardVolunteerTrainer() {
         RelatedObjects related = getRelatedFilesWithGroups(
             new List<string>{ 'Board', 'Volunteer', 'Trainer' }
         );
-        System.assert(related.items.size() < 6);
-        System.assertEquals(3, related.total);
+        System.assert(related.items.size() <= 6);
+        System.assertEquals(16, related.total);
     }
 
     @isTest
@@ -207,8 +121,8 @@ private class TestFileControllerRestrictions {
             new List<string>{ 'Board' }
         );
 
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
+        System.assertEquals(6, related.items.size());
+        System.assertEquals(7, related.total);
         System.assertEquals('Board', ((FileInfo) related.items[0]).category);
     }
 
@@ -218,8 +132,8 @@ private class TestFileControllerRestrictions {
             new List<string>{ 'Volunteer' }
         );
 
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
+        System.assertEquals(5, related.items.size());
+        System.assertEquals(5, related.total);
         System.assertEquals(
             'Volunteer',
             ((FileInfo) related.items[0]).category
@@ -227,24 +141,24 @@ private class TestFileControllerRestrictions {
     }
 
     @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForStaff() {
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForTrainer() {
         RelatedObjects related = getRelatedFilesWithGroups(
             new List<string>{ 'Trainer' }
         );
 
-        System.assertEquals(1, related.items.size());
-        System.assertEquals(1, related.total);
-        System.assertEquals('Trainer', ((FileInfo) related.items[0]).category);
+        System.assertEquals(6, related.items.size());
+        System.assertEquals(8, related.total);
+        System.assertEquals('Trainer', ((FileInfo) related.items[3]).category);
     }
 
     @isTest
-    public static void getRelatedFiles_ReturnsRelatedRecords_ForNone() {
+    public static void getRelatedFiles_ReturnsRelatedRecords_ForTeam() {
         RelatedObjects related = getRelatedFilesWithGroups(
             new List<string>{ 'Team' }
         );
 
-        System.assertEquals(0, related.items.size());
-        System.assertEquals(0, related.total);
+        System.assertEquals(6, related.items.size());
+        System.assertEquals(20, related.total);
     }
 
     @isTest
@@ -253,7 +167,7 @@ private class TestFileControllerRestrictions {
             new List<string>{ 'Board', 'Trainer' }
         );
 
-        System.assertEquals(2, related.items.size());
-        System.assertEquals(2, related.total);
+        System.assertEquals(6, related.items.size());
+        System.assertEquals(13, related.total);
     }
 }

--- a/force-app/main/test/TestFileControllerRestrictions.cls-meta.xml
+++ b/force-app/main/test/TestFileControllerRestrictions.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/TestUtilities.cls
+++ b/force-app/main/test/TestUtilities.cls
@@ -212,4 +212,90 @@ public with sharing class TestUtilities {
         };
         insert lookups;
     }
+    class MyPickListInfo {
+        public Boolean active;
+        public Boolean defaultValue;
+        public String label;
+        public String validFor;
+        public String value;
+    }
+    public static Map<String, List<String>> getCategoryTypeDependencies() {
+        Map<String, List<String>> controllingInfo = new Map<String, List<String>>();
+
+        Schema.SObjectType objType = Schema.getGlobalDescribe()
+            .get('ContentVersion');
+
+        Schema.DescribeSObjectResult describeResult = objType.getDescribe();
+        Schema.DescribeFieldResult controllingFieldInfo = describeResult.fields.getMap()
+            .get('Category__c')
+            .getDescribe();
+        Schema.DescribeFieldResult dependentFieldInfo = describeResult.fields.getMap()
+            .get('Type__c')
+            .getDescribe();
+
+        List<Schema.PicklistEntry> controllingValues = controllingFieldInfo.getPicklistValues();
+        List<Schema.PicklistEntry> dependentValues = dependentFieldInfo.getPicklistValues();
+
+        for (Schema.PicklistEntry currControllingValue : controllingValues) {
+            controllingInfo.put(
+                currControllingValue.getValue(),
+                new List<String>()
+            );
+        }
+
+        for (Schema.PicklistEntry currDependentValue : dependentValues) {
+            String jsonString = JSON.serialize(currDependentValue);
+
+            MyPickListInfo info = (MyPickListInfo) JSON.deserialize(
+                jsonString,
+                MyPickListInfo.class
+            );
+
+            String hexString = EncodingUtil.convertToHex(
+                    EncodingUtil.base64Decode(info.validFor)
+                )
+                .toUpperCase();
+
+            Integer baseCount = 0;
+
+            for (Integer curr : hexString.getChars()) {
+                Integer val = 0;
+
+                if (curr >= 65) {
+                    val = curr - 65 + 10;
+                } else {
+                    val = curr - 48;
+                }
+
+                if ((val & 8) == 8) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 0].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 4) == 4) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 1].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 2) == 2) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 2].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+                if ((val & 1) == 1) {
+                    controllingInfo.get(
+                            controllingValues[baseCount + 3].getValue()
+                        )
+                        .add(currDependentValue.getValue());
+                }
+
+                baseCount += 4;
+            }
+        }
+
+        return controllingInfo;
+    }
 }


### PR DESCRIPTION

# Critical Changes

1. Fixed filtering of related files by the groups a user is in.
2. Corrected number of files returned in related files component.
3. Cleaned up the trigger for ContentDocumentLink to remove SOQL queries before the document is linked to an object.
4. Corrected sorting of files in related list.
5. Corrected sorting of facilitator and submitter in related logs (filter by name rather than id).

# Changes

# Issues Closed
#560