### PR TITLE
Feature/555 trainer certification valid until

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -21,3 +21,7 @@ package.xml
 **/npsp__*
 **/npe01__*
 **/npo02__*
+
+**/tsconfig.json
+
+**/*.ts

--- a/force-app/main/default/classes/ContactService.cls
+++ b/force-app/main/default/classes/ContactService.cls
@@ -363,4 +363,72 @@ public with sharing class ContactService {
             );
         }
     }
+
+    class Dates {
+        public Date initial { get; set; }
+        public Date expiration { get; set; }
+    }
+
+    public static void updateCertValidUntil(Contact trainer) {
+        // check to see if settings are missing
+        Boolean updateSettings = false;
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        if (settings.CertRenewalYears__c == null) {
+            // TODO: get default value
+            settings.CertRenewalYears__c = 1;
+            updateSettings = true;
+        }
+        if (settings.EarlyRenewal__c == null) {
+            // TODO: get default value
+            settings.EarlyRenewal__c = 90;
+            updateSettings = true;
+        }
+        if (settings.RenewalLeeway__c == null) {
+            // TODO: get default value
+            settings.RenewalLeeway__c = 30;
+            updateSettings = true;
+        }
+        if (updateSettings) {
+            upsert settings;
+        }
+        Integer years = (Integer) settings.CertRenewalYears__c;
+        Integer early = (Integer) settings.EarlyRenewal__c;
+        Integer leeway = (Integer) settings.RenewalLeeway__c;
+        if (
+            trainer.IsTrainer__c &&
+            trainer.TrainerCertAgreementReceived__c != null
+        ) {
+            if (trainer.TrainerInitialCertificationDate__c == null) {
+                trainer.TrainerInitialCertificationDate__c = trainer.TrainerCertAgreementReceived__c;
+                trainer.TrainerCertValidUntil__c = trainer.TrainerCertAgreementReceived__c.addYears(1);
+                return;
+            }
+            Integer days = trainer.TrainerCertAgreementReceived__c.daysBetween(trainer.TrainerCertValidUntil__c);
+            if (days >= -early && days <= leeway) {
+                trainer.TrainerCertValidUntil__c = trainer.TrainerCertValidUntil__c.addYears(years);
+            }
+        }
+    }
+
+    private static Dates getCertExpiration(
+        Date initial,
+        Date agreement,
+        Integer early,
+        Integer years,
+        Integer leeway
+    ) {
+        Dates cdates = new Dates();
+        cdates.initial = initial;
+        if (agreement == null) {
+            return cdates;
+        }
+        if (initial == null) {
+            cdates.initial = agreement;
+            cdates.expiration = agreement.addYears(years);
+        } else {
+            Integer moreYears = (agreement.daysBetween(initial) + 365 + leeway) / 365;
+            cdates.expiration = initial.addYears(moreYears);
+        }
+        return cdates;
+    }
 }

--- a/force-app/main/default/objects/AtlasSettings__c/AtlasSettings__c.object-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/AtlasSettings__c.object-meta.xml
@@ -1,8 +1,2 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-    <customSettingsType>Hierarchy</customSettingsType>
-    <description>Settings for the Atlas Assistance Dogs app</description>
-    <enableFeeds>false</enableFeeds>
-    <label>Atlas Settings</label>
-    <visibility>Public</visibility>
-</CustomObject>
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata"></CustomObject>

--- a/force-app/main/default/objects/AtlasSettings__c/fields/CertRenewalYears__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/CertRenewalYears__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CertRenewalYears__c</fullName>
+    <defaultValue>1</defaultValue>
+    <description>Years between Certification renewals</description>
+    <externalId>false</externalId>
+    <label>Certification Renewal Years</label>
+    <precision>1</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/AtlasSettings__c/fields/EarlyRenewal__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/EarlyRenewal__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>RenewalLeeway__c</fullName>
-    <defaultValue>30</defaultValue>
-    <description>Number of days leeway after expiration dates to extend certification by a year</description>
+    <fullName>EarlyRenewal__c</fullName>
+    <defaultValue>90</defaultValue>
+    <description>Number of days leeway before expiration dates to increment valid until</description>
     <externalId>false</externalId>
-    <label>Renewal Leeway</label>
+    <label>Early Renewal Days</label>
     <precision>3</precision>
     <required>false</required>
     <scale>0</scale>

--- a/force-app/main/default/objects/AtlasSettings__c/fields/RenewalLeeway__c.field-meta.xml
+++ b/force-app/main/default/objects/AtlasSettings__c/fields/RenewalLeeway__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RenewalLeeway__c</fullName>
+    <defaultValue>30</defaultValue>
+    <description>Number of days leeway before expiration dates to increment valid until</description>
+    <externalId>false</externalId>
+    <label>Renewal Leeway</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Contact/fields/TrainerCertValidUntil__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/TrainerCertValidUntil__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TrainerCertValidUntil__c</fullName>
+    <description>The date the Trainer Certification is valid to</description>
+    <externalId>false</externalId>
+    <label>Trainer Certification Valid Until</label>
+    <required>false</required>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/Contact/fields/TrainerCertificationValidUntil__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/TrainerCertificationValidUntil__c.field-meta.xml
@@ -6,9 +6,9 @@
     <formula>IF( ISNULL(TrainerCertAgreementReceived__c),
  /* Find the number of years that have
     passed between the Last Cert Agreement and the Initial Cert Date. Certification is valid for
-    that many years */
+    that many years, with a leeway from custom settings. */
  ADDMONTHS(TrainerInitialCertificationDate__c, 12),
- ADDMONTHS(TrainerInitialCertificationDate__c, FLOOR(((TrainerCertAgreementReceived__c - TrainerInitialCertificationDate__c) + 365) / 365) * 12) )</formula>
+ ADDMONTHS(TrainerInitialCertificationDate__c, FLOOR((TrainerCertAgreementReceived__c - TrainerInitialCertificationDate__c + 365 +  $Setup.AtlasSettings__c.RenewalLeeway__c ) / 365) * 12) )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Trainer Certification Valid Until</label>
     <required>false</required>

--- a/force-app/main/default/objects/Contact/fields/TrainerCertificationValidUntil__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/TrainerCertificationValidUntil__c.field-meta.xml
@@ -8,7 +8,7 @@
     passed between the Last Cert Agreement and the Initial Cert Date. Certification is valid for
     that many years, with a leeway from custom settings. */
  ADDMONTHS(TrainerInitialCertificationDate__c, 12),
- ADDMONTHS(TrainerInitialCertificationDate__c, FLOOR((TrainerCertAgreementReceived__c - TrainerInitialCertificationDate__c + 365 +  $Setup.AtlasSettings__c.RenewalLeeway__c ) / 365) * 12) )</formula>
+ ADDMONTHS(TrainerInitialCertificationDate__c, FLOOR((TrainerCertAgreementReceived__c - TrainerInitialCertificationDate__c + 365 + $Setup.AtlasSettings__c.RenewalLeeway__c ) / 365) * 12) )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Trainer Certification Valid Until</label>
     <required>false</required>

--- a/force-app/main/default/triggers/ContactTrigger.trigger
+++ b/force-app/main/default/triggers/ContactTrigger.trigger
@@ -55,6 +55,10 @@ trigger ContactTrigger on Contact (before insert, before update) {
         }
 
         ContactService.updateFirstAidValidUntil(newContact, oldFirstAidDate);
+
+        if (newContact.isTrainer__c && newContact.TrainerCertAgreementReceived__c != null) {
+            ContactService.updateCertValidUntil(newContact);
+        }
     }
 
     if (!Trigger.isInsert) {

--- a/force-app/main/test/TestContactTrigger.cls
+++ b/force-app/main/test/TestContactTrigger.cls
@@ -308,4 +308,65 @@ public with sharing class TestContactTrigger {
         System.assert(result.getErrors().size() == 0);
         System.assertEquals(null, saved.FirstAidValidUntil__c);
     }
+
+    @isTest
+    static void update_setsTrainerCertValidUntil_whenFirstCert() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            Positions__c = 'Trainer'
+        );
+        insert joe;
+
+        joe.TrainerCertAgreementReceived__c = received;
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, TrainerInitialCertificationDate__c, TrainerCertValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(received, saved.TrainerInitialCertificationDate__c);
+        System.assertEquals(received.addYears(1), saved.TrainerCertValidUntil__c);
+    }
+
+    @isTest
+    static void update_changesTrainerCertValidUntil_when30daysBefore() {
+        AtlasSettings__c settings = AtlasSettings__c.getOrgDefaults();
+        upsert settings;
+        Date received = Date.newInstance(2022, 12, 25);
+
+        Contact joe = new Contact(
+            Email = 'joe-blow@pump.com',
+            FirstName = 'Joe',
+            LastName = 'Blow',
+            Positions__c = 'Trainer',
+            TrainerInitialCertificationDate__c = received,
+            TrainerCertAgreementReceived__c = received,
+            TrainerCertValidUntil__c = received.addYears(1)
+        );
+        insert joe;
+
+        joe.TrainerCertAgreementReceived__c = received.addYears(1).addDays(-30);
+
+        // Act
+        Test.startTest();
+        Database.SaveResult result = Database.update(joe, true);
+        Test.stopTest();
+
+        // Assert
+        System.assert(result.isSuccess());
+        Contact saved = [SELECT id, TrainerInitialCertificationDate__c, TrainerCertValidUntil__c FROM Contact WHERE id = :result.getId()];
+        System.assert(result.getErrors().size() == 0);
+        System.assertEquals(received, saved.TrainerInitialCertificationDate__c);
+        System.assertEquals(received.addYears(2), saved.TrainerCertValidUntil__c);
+    }
 }

--- a/force-app/main/test/TestFormulaFields.cls
+++ b/force-app/main/test/TestFormulaFields.cls
@@ -1,0 +1,11 @@
+/**
+ * This class contains unit tests for validating the behavior of formula fields.
+ */
+@isTest
+private class TestFormulaFields {
+
+    @isTest
+    static void TrainerCertificationValidUntil_ShowsDateAfterLastCert() {
+        // TO DO: implement unit test
+    }
+}

--- a/force-app/main/test/TestFormulaFields.cls-meta.xml
+++ b/force-app/main/test/TestFormulaFields.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION

# Critical Changes

# Changes
Created new field with same label as formula field.
Added trigger logic to set Cert valid until.
Added fields to Atlas Settings for Certification length and leeway before and after expiration for renewal to anniversary date.

# Issues Closed
#555