### PR TITLE
605 Remove trigger to set Team initial cert

### DIFF
--- a/force-app/main/default/classes/certifications/CertificationService.cls
+++ b/force-app/main/default/classes/certifications/CertificationService.cls
@@ -165,13 +165,12 @@ public inherited sharing class CertificationService {
   /* This is called when a new certification agreement is received for a contact.
    * If this is the first certification for the contact (identified by validUntil being null),
    *   Creates a new certification and exits.
-   * It update the current certification (if there is an active one, otherwise it creates a cert for the just-completed period)
+   * It update the current certification (if there is an active one, otherwise it creates a cert for the just-completed period).
    *   If the new certDate is within the leeway period, it completes the old cert and creates a new one starting when the old ends.
    *   If the new certDate is after the leeway, it completes the old cert and creates a new one starting on the certDate
    *   If the new certDate is somewhere else, it leaves the current cert in effect.
    */
-  public Certification__c updateCert(Contact person, String type, Date validUntil,   // date the most recent cert was valid until
-  Date certDate) {
+  public Certification__c updateCert(Contact person, String type, Date validUntil, Date certDate) {
     // date the latest agreement was received
     Dates dates = new Dates();
     Certification__c cert;

--- a/force-app/main/default/classes/teams/TeamService.cls
+++ b/force-app/main/default/classes/teams/TeamService.cls
@@ -100,16 +100,6 @@ public inherited sharing class TeamService{
     teamRepo.modify(teams);
   }
 
-  // Set InitialCertificationDate when first ClientCertAgreementReceived.
-  // Called from TeamTriggerBefore
-  public void setTeamHandler(List<Team__c> teams) {
-    for (Team__c team : teams) {
-      if (team.ClientCertAgreementReceived__c != null && team.InitialCertificationDate__c == null) {
-        team.InitialCertificationDate__c = team.ClientCertAgreementReceived__c;
-      }
-    }
-  }
-
   // Set the client/facilitator relationship.
   // This is meant to be called from the team update trigger.
   public void setClientFacilitatorRelationShip(Team__c newTeam){

--- a/force-app/main/default/triggers/TeamTriggerBefore.trigger
+++ b/force-app/main/default/triggers/TeamTriggerBefore.trigger
@@ -1,5 +1,0 @@
-trigger TeamTriggerBefore on Team__c(before insert, before update ) {
-    TeamService service = new TeamService();
-
-    service.setTeamHandler(Trigger.new);
-}


### PR DESCRIPTION
# Critical Changes

# Changes
Removed auto-setting initial certification dates on the team trigger.

# Issues Closed
#605