### PR TITLE
default to reminding facilitator if no training start

### DIFF
--- a/force-app/main/default/classes/teams/TeamService.cls
+++ b/force-app/main/default/classes/teams/TeamService.cls
@@ -1,5 +1,5 @@
-public inherited sharing class TeamService{
-  public TeamService(){
+public inherited sharing class TeamService {
+  public TeamService() {
     this.patRepo = new PublicAccessTestRepository();
     this.dogRepo = new DogRepository();
     this.contactRepo = new ContactRepository();
@@ -9,7 +9,7 @@ public inherited sharing class TeamService{
   }
 
   @TestVisible
-  private TeamService(TeamRepository teamRepo, PublicAccessTestRepository patRepo, RelationshipRepository relationshipRepo, EmailService emailServ, DogRepository dogRepo, ContactRepository contactRepo){
+  private TeamService(TeamRepository teamRepo, PublicAccessTestRepository patRepo, RelationshipRepository relationshipRepo, EmailService emailServ, DogRepository dogRepo, ContactRepository contactRepo) {
     this.patRepo = patRepo;
     this.dogRepo = dogRepo;
     this.contactRepo = contactRepo;
@@ -26,29 +26,29 @@ public inherited sharing class TeamService{
   private EmailService emailServ;
   // Set the dog/client relationship.
   // This is meant to be called from the team update trigger.
-  public void setClientDogRelationShip(Team__c newTeam){
+  public void setClientDogRelationShip(Team__c newTeam) {
     // See if there is an existing relationship between the dog and client
     List<DogRelationShip__c> relationShips = dogRepo.getRelationships(newTeam.Client__c, newTeam.Dog__c);
 
-    if (relationShips.size() == 0){
+    if (relationShips.size() == 0) {
       DogRelationShip__c relationShip = new DogRelationShip__c(
         Contact__c = newTeam.Client__c, 
         Dog__c = newTeam.Dog__c, 
         Type__c = 'Client'
       );
       dogRepo.createRelationship(relationShip);
-    } else{
+    } else {
       // add client to the type if not already there
-      for (DogRelationShip__c relationShip : relationShips){
-        if (relationShip.Type__c != null && relationShip.Type__c.contains('Client')){
+      for (DogRelationShip__c relationShip : relationShips) {
+        if (relationShip.Type__c != null && relationShip.Type__c.contains('Client')) {
           return;
         }
       }
       // otherwise, add Client to the first relationship (should be the only one)
       DogRelationShip__c relationShip = relationShips[0];
-      if (String.isBlank(relationShip.Type__c)){
+      if (String.isBlank(relationShip.Type__c)) {
         relationShip.Type__c = 'Client';
-      } else{
+      } else {
         relationShip.Type__c = relationShip.Type__c + ';Client';
       }
       dogRepo.modifyRelationship(relationShip);
@@ -56,16 +56,16 @@ public inherited sharing class TeamService{
   }
 
   // Update client status.  This is meant to be called from the team update trigger.
-  public void updateClientStatus(Team__c team){
+  public void updateClientStatus(Team__c team) {
     Contact client = contactRepo.getClientStatus(team.Client__c);
 
-    if (client != null){
+    if (client != null) {
       Dog__c dog = dogRepo.getById(team.Dog__c);
       client.ClientCertificationValidUntil__c = team.PatValidUntil__c;
       client.ClientStatus__c = team.Status__c;
       client.ClientInitialCertificationDate__c = team.InitialCertificationDate__c;
       client.ClientFacilitatorAvailability__c = team.FacilitatorAvailability__c;
-      if (dog != null){
+      if (dog != null) {
         client.ClientDog__c = dog.Name;
       }
       contactRepo.modify(client);
@@ -73,10 +73,10 @@ public inherited sharing class TeamService{
   }
 
   // Update client status.  This is meant to be called from the team update trigger.
-  public void updateDogStatus(Team__c team){
+  public void updateDogStatus(Team__c team) {
     Dog__c dog = dogRepo.getById(team.Dog__c);
 
-    if (dog != null){
+    if (dog != null) {
       dog.Status__c = team.Status__c;
       dog.XrayRequired__c = team.XrayRequired__c;
       dogRepo.modify(dog);
@@ -84,14 +84,14 @@ public inherited sharing class TeamService{
   }
 
   // Update PAT information
-  public void updatePatInformation(Set<Id> teamIds){
+  public void updatePatInformation(Set<Id> teamIds) {
     List<Team__c> teams = teamRepo.getByIds(teamIds);
 
-    for (Team__c team : teams){
+    for (Team__c team : teams) {
       List<PublicAccessTest__c> passingPats = patRepo.getPassing(team.Id);
-      if (passingPats.isEmpty()){
+      if (passingPats.isEmpty()) {
         team.PatValidUntil__c = null;
-      } else if (team.PatValidUntil__c != passingPats[0].ValidUntil__c){
+      } else if (team.PatValidUntil__c != passingPats[0].ValidUntil__c) {
         team.PatValidUntil__c = passingPats[0].ValidUntil__c;
       }
       team.PatCount__c = passingPats.size();
@@ -102,7 +102,7 @@ public inherited sharing class TeamService{
 
   // Set the client/facilitator relationship.
   // This is meant to be called from the team update trigger.
-  public void setClientFacilitatorRelationShip(Team__c newTeam){
+  public void setClientFacilitatorRelationShip(Team__c newTeam) {
     if (newTeam.Facilitator__c == null)
       return;
     // nothing to do
@@ -110,8 +110,8 @@ public inherited sharing class TeamService{
     List<npe4__Relationship__c> relationShips = relationshipRepo.getForPair(newTeam.Client__c, newTeam.Facilitator__c, 'Team Faciliator');
 
     // see if there is an existing relationship object to use
-    for (npe4__Relationship__c relationShip : relationShips){
-      if (relationShip.npe4__Status__c == 'Current'){
+    for (npe4__Relationship__c relationShip : relationShips) {
+      if (relationShip.npe4__Status__c == 'Current') {
         return;
       }
       // Set the status to current if not
@@ -130,55 +130,60 @@ public inherited sharing class TeamService{
   }
 
   // Remind the client in a Team to submit training logs
-  public void remindClients(){
+  public void remindClients() {
     List<Team__c> teams = teamRepo.getByStatus('In Training');
-    if (teams.isEmpty())
-      {return;}
+    if (teams.isEmpty()) {
+      return;
+    }
     // Loop through the teams and remind the clients that haven't logged this week
     Id orgAddressId = emailServ.getOrgEmailAddressId();
     EmailTemplate template = emailServ.getTemplate('ClientLogReminder');
 
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
-    for (Team__c team : teams){
+    for (Team__c team : teams) {
       emails.add(createEmail(team.Id, team.Client__c, template.Id, orgAddressId));
     }
     emailServ.sendEmail(emails);
   }
 
   // Remind the client facilitators to submit training logs
-  public void remindFacilitators(){
+  public void remindFacilitators() {
     List<Team__c> teams = teamRepo.getByStatus('In Training');
-    if (teams.isEmpty())
-     { return;}
+    if (teams.isEmpty()) {
+      return;
+    }
     // Get the org email address and template
     Id orgAddressId = emailServ.getOrgEmailAddressId();
     EmailTemplate template = emailServ.getTemplate('FacilitatorLogReminder');
 
     Date today = Date.today();
     Map<Id, Id> teamContactIds = new Map<Id, Id>();
-    for (Team__c team : teams){
-      Integer weeks = team.TrainingStartDate__c.daysBetween(today) / 7;
-      if (Math.mod(weeks, 2) == 1){
+    for (Team__c team : teams) {
+      Integer weeks = 1; // default #weeks to 1.  If no TrainingStartDate, remind team facilitator weekly
+      if (team.TrainingStartDate__c != null) {
+        weeks = team.TrainingStartDate__c.daysBetween(today) / 7;
+      }
+      if (Math.mod(weeks, 2) == 1) {
         // remind the facilitators
         teamContactIds.put(team.Client__c, team.Id);
       }
     }
-    if (teamContactIds.isEmpty()){
+    if (teamContactIds.isEmpty()) {
       return;
     }
     List<npe4__Relationship__c> relationships = relationshipRepo.getCurrentRelated(teamContactIds.keySet(), 'Team Faciliator');
 
     // Loop through the teams and remind the faciltators for them
     List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
-    for (npe4__Relationship__c relationship : relationships){
+    for (npe4__Relationship__c relationship : relationships) {
       emails.add(createEmail(teamContactIds.get(relationship.npe4__Contact__c), relationship.npe4__RelatedContact__c, template.Id, orgAddressId));
     }
     emailServ.sendEmail(emails);
   }
 
-  private Messaging.SingleEmailMessage createEmail(Id teamId, Id contactId, Id templateId, Id emailAddressId){
+  private Messaging.SingleEmailMessage createEmail(Id teamId, Id contactId, Id templateId, Id emailAddressId) {
     Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
-    if (emailAddressId != null){
+    if (emailAddressId != null) {
       mail.setOrgWideEmailAddressId(emailAddressId);
     }
     mail.setTargetObjectId(contactId);
@@ -189,7 +194,7 @@ public inherited sharing class TeamService{
     mail.setWhatId(teamId);
     mail.setBccSender(false);
     mail.setUseSignature(false);
-    if (emailAddressId == null){
+    if (emailAddressId == null) {
       mail.setSenderDisplayName('Atlas Assistance Dogs');
     }
     mail.setSaveAsActivity(false);

--- a/force-app/main/test/teams/TestTeamServiceReminders.cls
+++ b/force-app/main/test/teams/TestTeamServiceReminders.cls
@@ -8,34 +8,23 @@ public with sharing class TestTeamServiceReminders {
   private static RelationshipRepository relationshipRepo;
   private static ContactRepository contactRepo;
   private static EmailService emailSrv;
+
   // references to mocks
   private static void makeData() {
     mocks = new MockProvider();
-    teamRepo = (TeamRepository) mocks.createMock(TeamRepository.class);
-    dogRepo = (DogRepository) mocks.createMock(DogRepository.class);
-    patRepo = (PublicAccessTestRepository) mocks.createMock(
-      PublicAccessTestRepository.class
-    );
-    relationshipRepo = (RelationshipRepository) mocks.createMock(
-      RelationshipRepository.class
-    );
-    ContactRepo = (ContactRepository) mocks.createMock(ContactRepository.class);
-    emailSrv = (EmailService) mocks.createMock(EmailService.class);
-    service = new TeamService(
-      teamRepo,
-      patRepo,
-      relationshipRepo,
-      emailSrv,
-      dogRepo,
-      contactRepo
-    );
+    teamRepo = (TeamRepository)mocks.createMock(TeamRepository.class);
+    dogRepo = (DogRepository)mocks.createMock(DogRepository.class);
+    patRepo = (PublicAccessTestRepository)mocks.createMock(PublicAccessTestRepository.class);
+    relationshipRepo = (RelationshipRepository)mocks.createMock(RelationshipRepository.class);
+    ContactRepo = (ContactRepository)mocks.createMock(ContactRepository.class);
+    emailSrv = (EmailService)mocks.createMock(EmailService.class);
+    service = new TeamService(teamRepo, patRepo, relationshipRepo, emailSrv, dogRepo, contactRepo);
   }
+
   @isTest
   static void remindClients_sendsNoEmails_whenNoTeams() {
     makeData();
-    mocks.expectedCalls.add(
-      new MockCallData(teamRepo, 'getByStatus', new List<Team__c>())
-    );
+    mocks.expectedCalls.add(new MockCallData(teamRepo, 'getByStatus', new List<Team__c>()));
     service.remindClients();
     // Assert
     System.assert(!mocks.actualCalls.isEmpty());
@@ -47,31 +36,26 @@ public with sharing class TestTeamServiceReminders {
     // emails
     for (MockCallData call : mocks.actualCalls) {
       if (call.obj == emailSrv && call.methodName == 'sendEmail') {
-        System.assert(
-          ((List<Messaging.SingleEmailMessage>) call.args[0]).isEmpty()
-        );
+        System.assert(((List<Messaging.SingleEmailMessage>)call.args[0]).isEmpty());
       }
     }
   }
+
   @isTest
   static void remindClients_sendsEmailToClient_InTraining() {
     makeData();
     EmailTemplate template = new EmailTemplate(
       Id = MockProvider.createId(EmailTemplate.class)
     );
-    mocks.expectedCalls.add(
-      new MockCallData(emailSrv, 'getTemplate', template)
-    );
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'getTemplate', template));
     mocks.expectedCalls.add(new MockCallData(emailSrv, 'sendEmail'));
     Team__c team = new Team__c(
-      Id = MockProvider.createId(Team__c.class),
-      Client__c = MockProvider.createId(Contact.class),
-      Status__c = 'In Training',
+      Id = MockProvider.createId(Team__c.class), 
+      Client__c = MockProvider.createId(Contact.class), 
+      Status__c = 'In Training', 
       TrainingStartDate__c = Date.today().addDays(-6)
     );
-    mocks.expectedCalls.add(
-      new MockCallData(teamRepo, 'getByStatus', new List<Team__c>{ team })
-    );
+    mocks.expectedCalls.add(new MockCallData(teamRepo, 'getByStatus', new List<Team__c>{ team }));
     service.remindClients();
     // Assert
     System.assert(!mocks.actualCalls.isEmpty());
@@ -81,22 +65,23 @@ public with sharing class TestTeamServiceReminders {
     System.assertEquals('In Training', getTeams.args[0]);
     // the last call would be to send emails
     MockCallData data = mocks.actualCalls[mocks.actualCalls.size() - 1];
-    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>) data.args[0];
+    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>)data.args[0];
     System.assertEquals(1, emails.size());
     Messaging.SingleEmailMessage message = emails[0];
     System.assertEquals(team.Client__c, message.targetobjectid);
     System.assertEquals(team.Id, message.whatid);
     System.assertEquals(template.Id, message.templateid);
   }
+
   @isTest
   static void remindClients_sendsEmailsToClients_InTraining() {
     makeData();
     Team__c[] teams = new Team__c[5];
     for (Integer i = 0; i < 5; i++) {
       teams[i] = new Team__c(
-        Id = MockProvider.createId(Team__c.class),
-        Client__c = MockProvider.createId(Contact.class),
-        Status__c = 'In Training',
+        Id = MockProvider.createId(Team__c.class), 
+        Client__c = MockProvider.createId(Contact.class), 
+        Status__c = 'In Training', 
         TrainingStartDate__c = Date.today().addDays(0 - i)
       );
     }
@@ -104,15 +89,13 @@ public with sharing class TestTeamServiceReminders {
     EmailTemplate template = new EmailTemplate(
       Id = MockProvider.createId(EmailTemplate.class)
     );
-    mocks.expectedCalls.add(
-      new MockCallData(emailSrv, 'getTemplate', template)
-    );
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'getTemplate', template));
     mocks.expectedCalls.add(new MockCallData(emailSrv, 'sendEmail'));
     service.remindClients();
     // Assert
     // the last call would be to send emails
     MockCallData data = mocks.actualCalls[mocks.actualCalls.size() - 1];
-    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>) data.args[0];
+    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>)data.args[0];
     for (Integer i = 0; i < 5; i++) {
       Team__c team = teams[i];
       Messaging.SingleEmailMessage message = emails[i];
@@ -126,27 +109,22 @@ public with sharing class TestTeamServiceReminders {
   private static Set<Id> facilitatorIds = new Set<Id>();
   private static Set<Id> clientIds = new Set<Id>();
   private static EmailTemplate template;
-
   private static void setupCalls(Integer[] daysTraining) {
     makeData();
     template = new EmailTemplate(
       Id = MockProvider.createId(EmailTemplate.class)
     );
-    mocks.expectedCalls.add(
-      new MockCallData(emailSrv, 'getTemplate', template)
-    );
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'getTemplate', template));
     mocks.expectedCalls.add(new MockCallData(emailSrv, 'sendEmail'));
     List<Team__c> teams = new List<Team__c>();
     for (Integer i = 0; i < daysTraining.size(); i++) {
       Integer days = daysTraining[i];
-      teams.add(
-        new Team__c(
-          Id = MockProvider.createId(Team__c.class),
-          Client__c = MockProvider.createId(Contact.class),
-          Status__c = 'In Training',
-          TrainingStartDate__c = Date.today().addDays(0 - days)
-        )
-      );
+      teams.add(new Team__c(
+        Id = MockProvider.createId(Team__c.class), 
+        Client__c = MockProvider.createId(Contact.class), 
+        Status__c = 'In Training', 
+        TrainingStartDate__c = Date.today().addDays(0 - days)
+      ));
     }
     mocks.expectedCalls.add(new MockCallData(teamRepo, 'getByStatus', teams));
     facilitatorToTeamIds = new Map<Id, Id>();
@@ -155,22 +133,18 @@ public with sharing class TestTeamServiceReminders {
     List<npe4__Relationship__c> relationships = new List<npe4__Relationship__c>();
     for (Integer i = 0; i < daysTraining.size(); i++) {
       Id currentId = MockProvider.createId(Contact.class);
-      relationships.add(
-        new npe4__Relationship__c(
-          Id = MockProvider.createId(npe4__Relationship__c.class),
-          npe4__Contact__c = teams[i].Client__c,
-          npe4__RelatedContact__c = currentId
-        )
-      );
+      relationships.add(new npe4__Relationship__c(
+        Id = MockProvider.createId(npe4__Relationship__c.class), 
+        npe4__Contact__c = teams[i].Client__c, 
+        npe4__RelatedContact__c = currentId
+      ));
       facilitatorIds.add(currentId);
       clientIds.add(teams[i].Client__c);
       facilitatorToTeamIds.put(currentId, teams[i].Id);
     }
-    mocks.expectedCalls.add(
-      new MockCallData(relationshipRepo, 'getCurrentRelated', relationships)
-    );
+    mocks.expectedCalls.add(new MockCallData(relationshipRepo, 'getCurrentRelated', relationships));
   }
-  
+
   @isTest
   static void remindFacilitators_sendsEmailsToFacilitators() {
     // Arrange
@@ -197,14 +171,11 @@ public with sharing class TestTeamServiceReminders {
     System.assertEquals('Team Faciliator', getFac.args[1]);
     // the last call would be to send emails
     MockCallData data = mocks.actualCalls[mocks.actualCalls.size() - 1];
-    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>) data.args[0];
+    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>)data.args[0];
     System.assertEquals(7, emails.size());
     for (Messaging.SingleEmailMessage message : emails) {
       System.assert(facilitatorIds.contains(message.targetobjectid));
-      System.assertEquals(
-        facilitatorToTeamIds.get(message.targetObjectId),
-        message.whatid
-      );
+      System.assertEquals(facilitatorToTeamIds.get(message.targetObjectId), message.whatid);
       System.assertEquals(template.Id, message.templateid);
       facilitatorIds.remove(message.targetobjectid);
     }
@@ -233,6 +204,7 @@ public with sharing class TestTeamServiceReminders {
     System.assertEquals(null, getFac);
     System.assertEquals(null, sendEmail);
   }
+
   @isTest
   static void remindFacilitators_sendsNoEmailWhenTrainingJustStarted() {
     // Arrange
@@ -258,37 +230,59 @@ public with sharing class TestTeamServiceReminders {
     System.assertEquals(null, getFac);
     System.assertEquals(null, sendEmail);
   }
+
   @isTest
   static void remindFacilitators_sendsNoEmails_whenNoFacilitators() {
     makeData();
-    mocks.expectedCalls.add(
-      new MockCallData(
-        emailSrv,
-        'getTemplate',
-        new EmailTemplate(Id = MockProvider.createId(EmailTemplate.class))
-      )
-    );
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'getTemplate', new EmailTemplate(
+      Id = MockProvider.createId(EmailTemplate.class)
+    )));
     mocks.expectedCalls.add(new MockCallData(emailSrv, 'sendEmail'));
     Team__c team = new Team__c(
-      Id = MockProvider.createId(Team__c.class),
-      Client__c = MockProvider.createId(EmailTemplate.class),
-      Status__c = 'In Training',
+      Id = MockProvider.createId(Team__c.class), 
+      Client__c = MockProvider.createId(EmailTemplate.class), 
+      Status__c = 'In Training', 
       TrainingStartDate__c = Date.today().addDays(-8)
     );
-    mocks.expectedCalls.add(
-      new MockCallData(teamRepo, 'getByStatus', new List<Team__c>{ team })
-    );
-    List<npe4__Relationship__c> relationships = new List<npe4__Relationship__c>{};
-    mocks.expectedCalls.add(
-      new MockCallData(relationshipRepo, 'getCurrentRelated', relationships)
-    );
+    mocks.expectedCalls.add(new MockCallData(teamRepo, 'getByStatus', new List<Team__c>{ team }));
+    List<npe4__Relationship__c> relationships = new List<npe4__Relationship__c>{  };
+    mocks.expectedCalls.add(new MockCallData(relationshipRepo, 'getCurrentRelated', relationships));
     service.remindFacilitators();
     // Assert
     System.assert(!mocks.actualCalls.isEmpty());
     // the last call would be to send emails
     MockCallData data = mocks.actualCalls[mocks.actualCalls.size() - 1];
-    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>) data.args[0];
+    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>)data.args[0];
     System.assertEquals(0, emails.size());
   }
-    
+
+  @isTest
+  static void remindFacilitators_sendsEmail_whenNoStartDate() {
+    makeData();
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'getTemplate', new EmailTemplate(
+      Id = MockProvider.createId(EmailTemplate.class)
+    )));
+    mocks.expectedCalls.add(new MockCallData(emailSrv, 'sendEmail'));
+    Team__c team = new Team__c(
+      Id = MockProvider.createId(Team__c.class), 
+      Client__c = MockProvider.createId(EmailTemplate.class), 
+      Status__c = 'In Training'
+    );
+    mocks.expectedCalls.add(new MockCallData(teamRepo, 'getByStatus', new List<Team__c>{ team }));
+    Id facId = MockProvider.createId(Contact.class);
+    List<npe4__Relationship__c> relationships = new List<npe4__Relationship__c>{ new npe4__Relationship__c(
+      Id = MockProvider.createId(npe4__Relationship__c.class), 
+      npe4__Contact__c = team.Client__c, 
+      npe4__RelatedContact__c = facId
+    ) };
+    mocks.expectedCalls.add(new MockCallData(relationshipRepo, 'getCurrentRelated', relationships));
+    service.remindFacilitators();
+    // Assert
+    System.assert(!mocks.actualCalls.isEmpty(), 'there should be calls');
+    // the last call would be to send emails
+    MockCallData data = mocks.actualCalls[mocks.actualCalls.size() - 1];
+    List<Messaging.SingleEmailMessage> emails = (List<Messaging.SingleEmailMessage>)data.args[0];
+    System.assertEquals(1, emails.size(), 'an email should be sent');
+  }
+
 }


### PR DESCRIPTION
# Critical Changes
Fix problem where remind facilitator task to submit logs fails because a team doesn't have a training start date.
